### PR TITLE
#16 テーマ切り替え機能の実装

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -8,6 +8,9 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - sqflite (0.0.2):
     - Flutter
     - FMDB (>= 2.7.5)
@@ -16,6 +19,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
 
 SPEC REPOS:
@@ -29,6 +33,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/ios"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
 
@@ -37,6 +43,7 @@ SPEC CHECKSUMS:
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
+  shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3

--- a/lib/constants/app_color.dart
+++ b/lib/constants/app_color.dart
@@ -1,0 +1,11 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class AppColor {
+  //shimmer
+  static const lightBaseColor = Color(0xffe0e0e0);
+  static const lightHighlightColor = Color(0xffeeeeee);
+  static const darkBaseColor = Color(0xff616161);
+  static const darkHighlightColor = Color(0xff757575);
+}

--- a/lib/constants/app_color.dart
+++ b/lib/constants/app_color.dart
@@ -8,4 +8,10 @@ class AppColor {
   static const lightHighlightColor = Color(0xffeeeeee);
   static const darkBaseColor = Color(0xff616161);
   static const darkHighlightColor = Color(0xff757575);
+
+//result count
+  static const lightBgColor = Color(0x991A1C19);
+  static const darkBgColor = Color(0x99FCFDF6);
+  static const lightCountColor = Color(0xffFCFDF6);
+  static const darkCountColor = Color(0xff1A1C19);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,31 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:yumemi_flutter_repo_search/presentation/search/search_page.dart';
 import 'package:yumemi_flutter_repo_search/repository/data_repository.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
+import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 import 'package:yumemi_flutter_repo_search/theme/theme.dart';
 
 final dataRepositoryProvider = Provider<DataRepository>((ref) {
   return DataRepository(client: ref.watch(httpClientProvider));
 });
 
-void main() {
-  runApp(const ProviderScope(child: MyApp()));
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(
+    ProviderScope(
+      overrides: [
+        //インスタンス取得は非同期なので初回に取得してキャッシュしておく
+        sharedPreferencesProvider.overrideWithValue(
+          await SharedPreferences.getInstance(),
+        ),
+      ],
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:yumemi_flutter_repo_search/repository/data_repository.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
 import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 import 'package:yumemi_flutter_repo_search/theme/theme.dart';
+import 'package:yumemi_flutter_repo_search/theme/theme_mode_provider.dart';
 
 final dataRepositoryProvider = Provider<DataRepository>((ref) {
   return DataRepository(client: ref.watch(httpClientProvider));
@@ -28,15 +29,15 @@ void main() async {
   );
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return MaterialApp(
       theme: lightTheme,
       darkTheme: darkTheme,
-      themeMode: ThemeMode.dark,
+      themeMode: ref.watch(themeModeProvider),
       home: const SearchPage(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,8 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: lightTheme,
+      darkTheme: darkTheme,
+      themeMode: ThemeMode.dark,
       home: const SearchPage(),
     );
   }

--- a/lib/presentation/controller/controllers.dart
+++ b/lib/presentation/controller/controllers.dart
@@ -16,6 +16,10 @@ final textEditingControllerProvider =
 final isClearButtonVisibleProvider =
     StateProvider.autoDispose<bool>((ref) => false);
 
+//検索結果数を表示するかのフラグ（スクロール中は非表示なので基本TRUE）
+final isResultCountVisibleProvider =
+    StateProvider.autoDispose<bool>((ref) => true);
+
 //データ
 final repoDataProvider = FutureProvider.autoDispose
     .family<RepoDataModel, String>((ref, repoName) async {

--- a/lib/presentation/search/search_page.dart
+++ b/lib/presentation/search/search_page.dart
@@ -9,6 +9,8 @@ import 'package:yumemi_flutter_repo_search/presentation/search/widget/list_item_
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/result_count.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/toggle_theme_switch.dart';
 
+import '../../theme/theme_mode_provider.dart';
+
 class SearchPage extends ConsumerWidget {
   const SearchPage({Key? key}) : super(key: key);
 
@@ -19,6 +21,16 @@ class SearchPage extends ConsumerWidget {
         ref.watch(repoDataProvider(ref.watch(inputRepoNameProvider)));
     //テキストのコントローラ
     final textController = ref.watch(textEditingControllerProvider);
+
+    //スイッチの初期値判定のためのシステムテーマモード取得
+    final systemThemeMode =
+        MediaQuery.of(context).platformBrightness == Brightness.dark
+            ? ThemeMode.dark
+            : ThemeMode.light;
+    //現在のテーマモード取得
+    final themeMode = ref.watch(themeModeProvider);
+    //theme切り替えのプロバイダ
+    final themeSelector = ref.read(themeModeProvider.notifier);
 
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
@@ -32,8 +44,13 @@ class SearchPage extends ConsumerWidget {
               const Text('GitHubサーチ'),
               //actionsで実装すると、端っこすぎる
               ToggleThemeSwitch(
-                value: false,
-                onToggle: (value) => print(value),
+                //themeModeが初期（SYSTEM）状態だったらその情報を使って表示を処理する
+                value: themeMode == ThemeMode.system
+                    ? systemThemeMode == ThemeMode.dark
+                    : themeMode == ThemeMode.dark,
+                onToggle: (value) {
+                  themeSelector.toggleThemeAndSave(value);
+                },
               ),
             ],
           ),

--- a/lib/presentation/search/search_page.dart
+++ b/lib/presentation/search/search_page.dart
@@ -8,7 +8,6 @@ import 'package:yumemi_flutter_repo_search/presentation/search/widget/list_item.
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/list_item_shimmer.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/result_count.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/toggle_theme_switch.dart';
-
 import '../../theme/theme_mode_provider.dart';
 
 class SearchPage extends ConsumerWidget {

--- a/lib/presentation/search/search_page.dart
+++ b/lib/presentation/search/search_page.dart
@@ -69,7 +69,7 @@ class SearchPage extends ConsumerWidget {
                 key: const Key('inputForm'),
               ),
             ),
-            const Divider(color: Colors.black12),
+            const Divider(),
             Expanded(
               flex: 8,
               child: Stack(

--- a/lib/presentation/search/search_page.dart
+++ b/lib/presentation/search/search_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_switch/flutter_switch.dart';
 
 import 'package:yumemi_flutter_repo_search/presentation/controller/controllers.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/error/error_widget.dart';

--- a/lib/presentation/search/search_page.dart
+++ b/lib/presentation/search/search_page.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_switch/flutter_switch.dart';
 
 import 'package:yumemi_flutter_repo_search/presentation/controller/controllers.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/error/error_widget.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/list_item.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/list_item_shimmer.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/result_count.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/toggle_theme_switch.dart';
 
 class SearchPage extends ConsumerWidget {
   const SearchPage({Key? key}) : super(key: key);
@@ -25,7 +27,17 @@ class SearchPage extends ConsumerWidget {
       child: Scaffold(
         resizeToAvoidBottomInset: false,
         appBar: AppBar(
-          title: const Text('GitHubサーチ'),
+          title: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('GitHubサーチ'),
+              //actionsで実装すると、端っこすぎる
+              ToggleThemeSwitch(
+                value: false,
+                onToggle: (value) => print(value),
+              ),
+            ],
+          ),
           key: const Key('searchPageAppBar'),
         ),
         body: Column(

--- a/lib/presentation/search/widget/list_item_shimmer.dart
+++ b/lib/presentation/search/widget/list_item_shimmer.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:shimmer/shimmer.dart';
 
+import '../../../constants/app_color.dart';
+
 class ListItemShimmer extends StatelessWidget {
   const ListItemShimmer({super.key});
 
@@ -10,8 +12,12 @@ class ListItemShimmer extends StatelessWidget {
     return SingleChildScrollView(
       child: Shimmer.fromColors(
         period: const Duration(milliseconds: 750),
-        baseColor: const Color(0xffe0e0e0),
-        highlightColor: const Color(0xffeeeeee),
+        baseColor: Theme.of(context).brightness == Brightness.light
+            ? AppColor.lightBaseColor
+            : AppColor.darkBaseColor,
+        highlightColor: Theme.of(context).brightness == Brightness.light
+            ? AppColor.lightHighlightColor
+            : AppColor.darkHighlightColor,
         child: ListView.separated(
           shrinkWrap: true,
           itemCount: 20,

--- a/lib/presentation/search/widget/result_count.dart
+++ b/lib/presentation/search/widget/result_count.dart
@@ -14,14 +14,16 @@ class ResultCount extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         decoration: BoxDecoration(
-          color: const Color(0xFF1A1C19).withOpacity(0.6),
+          // color: const Color(0xff1A1C19).withOpacity(0.6),
+          color: const Color(0xffFCFDF6).withOpacity(0.6),
           borderRadius: BorderRadius.circular(5),
         ),
         child: Text(
           '${NumberFormat('#,##0').format(resultCount)}件',
           style: const TextStyle(
             fontSize: 16,
-            color: Colors.white,
+            // color: Colors.white,
+            color: Colors.black,
             fontWeight: FontWeight.bold,
           ),
           key: const Key('resultCount'),

--- a/lib/presentation/search/widget/result_count.dart
+++ b/lib/presentation/search/widget/result_count.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:intl/intl.dart';
 
+import '../../../constants/app_color.dart';
+
 class ResultCount extends StatelessWidget {
   const ResultCount({required this.resultCount, Key? key}) : super(key: key);
 
@@ -14,16 +16,18 @@ class ResultCount extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         decoration: BoxDecoration(
-          // color: const Color(0xff1A1C19).withOpacity(0.6),
-          color: const Color(0xffFCFDF6).withOpacity(0.6),
+          color: Theme.of(context).brightness == Brightness.light
+              ? AppColor.lightBgColor
+              : AppColor.darkBgColor,
           borderRadius: BorderRadius.circular(5),
         ),
         child: Text(
           '${NumberFormat('#,##0').format(resultCount)}件',
-          style: const TextStyle(
+          style: TextStyle(
+            color: Theme.of(context).brightness == Brightness.light
+                ? AppColor.lightCountColor
+                : AppColor.darkCountColor,
             fontSize: 16,
-            // color: Colors.white,
-            color: Colors.black,
             fontWeight: FontWeight.bold,
           ),
           key: const Key('resultCount'),

--- a/lib/presentation/search/widget/toggle_theme_switch.dart
+++ b/lib/presentation/search/widget/toggle_theme_switch.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_switch/flutter_switch.dart';
+
+class ToggleThemeSwitch extends StatelessWidget {
+  const ToggleThemeSwitch(
+      {required this.value, required this.onToggle, Key? key})
+      : super(key: key);
+
+  final bool value;
+  final void Function(bool) onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return FlutterSwitch(
+      height: 30,
+      width: 60,
+      value: value,
+      onToggle: onToggle,
+      padding: 0,
+      toggleSize: 30,
+      activeToggleColor: const Color(0xFF0D3B74),
+      inactiveToggleColor: const Color(0xFFFFAB40),
+      activeSwitchBorder: Border.all(
+        color: const Color(0x42000000),
+        width: 1,
+      ),
+      inactiveSwitchBorder: Border.all(
+        color: const Color(0x42000000),
+        width: 1,
+      ),
+      activeColor: const Color(0xFF365377),
+      inactiveColor: const Color(0xFFFFE892),
+      activeIcon: const Icon(
+        Icons.nightlight_round,
+        color: Colors.orangeAccent,
+      ),
+      inactiveIcon: const Icon(
+        Icons.wb_sunny,
+        color: Colors.white,
+      ),
+    );
+  }
+}

--- a/lib/presentation/search/widget/toggle_theme_switch.dart
+++ b/lib/presentation/search/widget/toggle_theme_switch.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'package:flutter_switch/flutter_switch.dart';
 
 class ToggleThemeSwitch extends StatelessWidget {

--- a/lib/repository/data_repository.dart
+++ b/lib/repository/data_repository.dart
@@ -13,10 +13,10 @@ class DataRepository {
   Future<RepoDataModel> getData(String repoName) async {
     try {
       // //エラーテスト用URL
-      final apiUri = Uri.parse('https://httpstat.us/403');
+      // final apiUri = Uri.parse('https://httpstat.us/403');
 
-      // final apiUri =
-      //     Uri.parse('https://api.github.com/search/repositories?q=$repoName');
+      final apiUri =
+          Uri.parse('https://api.github.com/search/repositories?q=$repoName');
       http.Response response = await client.get(apiUri);
 
       if (response.statusCode == 200) {

--- a/lib/theme/shared_preferences_provider.dart
+++ b/lib/theme/shared_preferences_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+//初回に上書きしてキャッシュして使うので、直接アクセスはできないようにする
+final sharedPreferencesProvider =
+    Provider<SharedPreferences>((_) => throw UnimplementedError());

--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -44,3 +44,47 @@ ThemeData lightTheme = ThemeData.light().copyWith(
   // divider
   dividerColor: const Color(0x47000000),
 );
+
+//dark theme ----------------------------------
+ThemeData darkTheme = ThemeData.dark().copyWith(
+  scaffoldBackgroundColor: const Color(0xff1A1C19),
+  //appbar theme
+  appBarTheme: const AppBarTheme(
+    centerTitle: false,
+    backgroundColor: Color(0xff1A1C19),
+    elevation: 0,
+    titleTextStyle: TextStyle(
+      color: Color(0xffffffff),
+      fontWeight: FontWeight.bold,
+      fontSize: 20,
+    ),
+    iconTheme: IconThemeData(
+      color: Color(0xffffffff),
+    ),
+  ),
+
+  //textField theme
+  inputDecorationTheme: InputDecorationTheme(
+    prefixIconColor: const Color(0xff9e9e9e),
+    suffixIconColor: const Color(0xff9e9e9e),
+    fillColor: const Color(0xff454f45),
+    filled: true,
+    enabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(30),
+      borderSide: const BorderSide(
+        color: Colors.transparent,
+      ),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(30),
+      borderSide: const BorderSide(
+        color: Color(0xff9e9e9e),
+      ),
+    ),
+    contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+    isDense: true,
+  ),
+
+  // divider
+  dividerColor: const Color(0xff777777),
+);

--- a/lib/theme/theme_mode_provider.dart
+++ b/lib/theme/theme_mode_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
+
+// SharedPreferences保存用キー
+const _isDarkThemeKey = 'selectedThemeKey';
+
+final themeModeProvider = StateNotifierProvider<ThemeSelector, ThemeMode>(
+  ThemeSelector.new,
+);
+
+class ThemeSelector extends StateNotifier<ThemeMode> {
+  ThemeSelector(this._ref) : super(ThemeMode.system) {
+    // テーマが保存されていればテーマを反映、そうでなければ初期値のシステム依存
+    final isDarkTheme = _prefs.getBool(_isDarkThemeKey);
+    if (isDarkTheme == null) {
+      return;
+    }
+    state = isDarkTheme ? ThemeMode.dark : ThemeMode.light;
+  }
+
+  final Ref _ref;
+
+  // 選択したテーマを保存するためのローカル保存領域
+  late final _prefs = _ref.read(sharedPreferencesProvider);
+
+  // テーマの変更と保存
+  Future<void> toggleThemeAndSave(bool isDarkTheme) async {
+    await _prefs.setBool(_isDarkThemeKey, isDarkTheme);
+    state = isDarkTheme ? ThemeMode.dark : ThemeMode.light;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -275,6 +275,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  flutter_switch:
+    dependency: "direct main"
+    description:
+      name: flutter_switch
+      sha256: b91477f926bba135d2d203d7b24367492662d8d9c3aa6adb960b14c1087d3c41
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -288,6 +288,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   freezed:
     dependency: "direct dev"
     description:
@@ -618,6 +623,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "858aaa72d8f61637d64e776aca82e1c67e6d9ee07979123c5d17115031c1b13b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8304d8a1f7d21a429f91dee552792249362b68a331ac5c3c1caf370f658873f6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: cf2a42fb20148502022861f71698db12d937c7459345a1bdaa88fc91a91b3603
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "9d387433ca65717bbf1be88f4d5bb18f10508917a8fa2fb02e0fd0d7479a9afa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: fb5cf25c0235df2d0640ac1b1174f6466bd311f621574997ac59018a6664548d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: "74083203a8eae241e0de4a0d597dbedab3b8fef5563f33cf3c12d7e93c655ca5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "5e588e2efef56916a3b229c3bfe81e6a525665a454519ca51dbcc4236a274173"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   shimmer: ^2.0.0
   lottie: ^2.3.1
   flutter_switch: ^0.3.2
+  shared_preferences: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   cached_network_image: ^3.2.3
   shimmer: ^2.0.0
   lottie: ^2.3.1
+  flutter_switch: ^0.3.2
 
 dev_dependencies:
   flutter_test:

--- a/test/presentation/error_test.dart
+++ b/test/presentation/error_test.dart
@@ -4,15 +4,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:yumemi_flutter_repo_search/main.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
+import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 import '../repository/repository_mock_data.dart';
 import '../repository/repository_mock_test.mocks.dart';
 
 void main() {
   group('エラー等の表示ができているか', () {
     testWidgets('空文字を入力して”入力してください”が表示されるか', (WidgetTester tester) async {
+      //モックのデータをshared_preferencesにセットしておかないといけない
+      SharedPreferences.setMockInitialValues({});
       const data = RepositoryMockData.jsonData;
       final mockClient = MockClient();
       //空文字を送信するとリクエストはせず、エラーメッセージを表示する仕様
@@ -22,6 +26,9 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(overrides: [
           httpClientProvider.overrideWithValue(mockClient),
+          sharedPreferencesProvider.overrideWithValue(
+            await SharedPreferences.getInstance(),
+          ),
         ], child: const MyApp()),
       );
 
@@ -38,6 +45,7 @@ void main() {
     });
 
     testWidgets('結果が0だった時に、想定の表示がされるか', (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
       const emptyData = RepositoryMockData.emptyJsonData;
       final mockClient = MockClient();
       //結果が0のデータを返す
@@ -47,6 +55,9 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(overrides: [
           httpClientProvider.overrideWithValue(mockClient),
+          sharedPreferencesProvider.overrideWithValue(
+            await SharedPreferences.getInstance(),
+          ),
         ], child: const MyApp()),
       );
 
@@ -65,6 +76,7 @@ void main() {
     });
 
     testWidgets('リクエストが200以外の場合エラーが返るか', (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
       const data = RepositoryMockData.jsonData;
       final mockClient = MockClient();
       //リクエストが200以外（失敗）する想定
@@ -74,6 +86,9 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(overrides: [
           httpClientProvider.overrideWithValue(mockClient),
+          sharedPreferencesProvider.overrideWithValue(
+            await SharedPreferences.getInstance(),
+          ),
         ], child: const MyApp()),
       );
 
@@ -92,7 +107,7 @@ void main() {
     });
 
     testWidgets('通信状態じゃない時の検索でネットワークエラーが返るか', (WidgetTester tester) async {
-      // const data = RepositoryMockData.jsonData;
+      SharedPreferences.setMockInitialValues({});
       //リクエストを投げると、ネットワークエラーの例外をスローする
       final mockClient = MockClient();
       when(mockClient.get(any)).thenAnswer((_) async => throw 'Network Error');
@@ -101,6 +116,9 @@ void main() {
         ProviderScope(
           overrides: [
             httpClientProvider.overrideWithValue(mockClient),
+            sharedPreferencesProvider.overrideWithValue(
+              await SharedPreferences.getInstance(),
+            ),
           ],
           child: const MyApp(),
         ),

--- a/test/presentation/input_search_test.dart
+++ b/test/presentation/input_search_test.dart
@@ -4,15 +4,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:yumemi_flutter_repo_search/main.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
+import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 import '../repository/repository_mock_data.dart';
 import '../repository/repository_mock_test.mocks.dart';
 
 void main() {
   group('入力フォームのテスト', () {
     testWidgets('検索フォームのテスト', (WidgetTester tester) async {
+      //モックのデータをshared_preferencesにセットしておかないといけない
+      SharedPreferences.setMockInitialValues({});
       const data = RepositoryMockData.jsonData;
       final mockClient = MockClient();
       when(mockClient.get(any))
@@ -22,6 +26,9 @@ void main() {
         ProviderScope(overrides: [
           //mock clientでDI
           httpClientProvider.overrideWithValue(mockClient),
+          sharedPreferencesProvider.overrideWithValue(
+            await SharedPreferences.getInstance(),
+          ),
         ], child: const MyApp()),
       );
       //検索フォーム
@@ -55,6 +62,7 @@ void main() {
 
   group('リポジトリの検索に関するテスト', () {
     testWidgets('検索結果が表示されるか', (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
       const data = RepositoryMockData.jsonData;
       final mockClient = MockClient();
       when(mockClient.get(any))
@@ -64,6 +72,9 @@ void main() {
         ProviderScope(overrides: [
           //mock clientでDI
           httpClientProvider.overrideWithValue(mockClient),
+          sharedPreferencesProvider.overrideWithValue(
+            await SharedPreferences.getInstance(),
+          ),
         ], child: const MyApp()),
       );
 
@@ -91,6 +102,7 @@ void main() {
 
   group('詳細ページのテスト', () {
     testWidgets('遷移先の詳細ページの表示ができているか', (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
       const data = RepositoryMockData.jsonData;
       final mockClient = MockClient();
       when(mockClient.get(any))
@@ -100,6 +112,9 @@ void main() {
         ProviderScope(overrides: [
           //mock clientでDI
           httpClientProvider.overrideWithValue(mockClient),
+          sharedPreferencesProvider.overrideWithValue(
+            await SharedPreferences.getInstance(),
+          ),
         ], child: const MyApp()),
       );
 

--- a/test/theme/theme_store_test.dart
+++ b/test/theme/theme_store_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
 import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 import 'package:yumemi_flutter_repo_search/theme/theme_mode_provider.dart';
 

--- a/test/theme/theme_store_test.dart
+++ b/test/theme/theme_store_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
+import 'package:yumemi_flutter_repo_search/theme/theme_mode_provider.dart';
+
+void main() {
+  group('themeに関するテスト', () {
+    late ProviderContainer container;
+    // SharedPreferences保存用キー
+    const isDarkThemeKey = 'selectedThemeKey';
+
+    setUp(() => () {
+          return Future(() async {
+            SharedPreferences.setMockInitialValues({});
+            container = ProviderContainer(overrides: [
+              sharedPreferencesProvider.overrideWithValue(
+                await SharedPreferences.getInstance(),
+              ),
+            ]);
+          });
+        });
+
+    tearDown(() => () {
+          container.dispose();
+        });
+
+    test('初期状態でテーマモードが端末のシステム依存であること', () async {
+      SharedPreferences.setMockInitialValues({});
+      container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(
+          await SharedPreferences.getInstance(),
+        ),
+      ]);
+      final themeMode = container.read(themeModeProvider);
+      expect(themeMode, ThemeMode.system);
+    });
+
+    test('テーマが記憶されていたら、そのテーマモードになっていること', () async {
+      const isDark = false;
+      //テーマモードをライトモードに設定
+      SharedPreferences.setMockInitialValues({isDarkThemeKey: isDark});
+
+      container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(
+          await SharedPreferences.getInstance(),
+        ),
+      ]);
+
+      final themeMode = container.read(themeModeProvider);
+      expect(themeMode, ThemeMode.light);
+    });
+
+    test('darkテーマに切り替え、テーマモードの保存ができていること', () async {
+      SharedPreferences.setMockInitialValues({});
+      container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(
+          await SharedPreferences.getInstance(),
+        ),
+      ]);
+
+      final themeNotifier = container.read(themeModeProvider.notifier);
+      //toggle theme method →isDarkにtrueを入れてダークモードに変更
+      await themeNotifier.toggleThemeAndSave(true);
+      //themeNotifier.debugState　→　container.read(themeModeProvider); と同義
+      //テーマが切り替わっていることのテスト
+      expect(themeNotifier.debugState, ThemeMode.dark);
+
+      //テーマを管理しているBOOLが保存されているかのテスト
+      final prefs = container.read(sharedPreferencesProvider);
+      final theme = prefs.getBool(isDarkThemeKey);
+      expect(theme, true);
+    });
+
+    test('テーマが保存されていない状態で、テーマ切り替えスイッチが正常に表示されている', () async {
+      SharedPreferences.setMockInitialValues({});
+      container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(
+          await SharedPreferences.getInstance(),
+        ),
+      ]);
+
+      final themeNotifier = container.read(themeModeProvider.notifier);
+      //テーマ切り替えはしない
+      // await themeNotifier.toggleThemeAndSave(true);
+      //themeNotifier.debugState　→　container.read(themeModeProvider); と同義
+
+      //テーマが初期状態であることのテスト
+      final themeModeState = themeNotifier.debugState;
+      expect(themeModeState, ThemeMode.system);
+
+      //システムのテーマと、スイッチの表示が一致しているか
+      //systemのテーマモードをlightだとする↓
+      final bool initialSwitchBool = themeModeState == ThemeMode.system
+          ? ThemeMode.light == ThemeMode.dark
+          : themeModeState == ThemeMode.dark;
+
+      //switchのフラグはisDarkなのでsystemがlightの場合switchはfalseが期待される
+      expect(initialSwitchBool, false);
+    });
+  });
+}


### PR DESCRIPTION
## 概要
#16 対応
* ダークテーマを追加
* スイッチでテーマ切り替えを実装
* テーマ切り替え、保存のテストを書いた
* その他のテストが通るよう変更

## やってないこと
このPR内でやっていないことを書く

## スクリーンショット
<img width="361" alt="スクリーンショット 2023-04-04 17 35 10" src="https://user-images.githubusercontent.com/87256037/229735640-9d89111e-e602-4198-b61e-01cf8bfc8d8f.png">   <img width="367" alt="スクリーンショット 2023-04-04 17 35 20" src="https://user-images.githubusercontent.com/87256037/229735686-afcb227d-352f-4693-8081-96b341b9928e.png">


## テスト
テスト項目、テスト方法を書く
ユニットテスト
* テーマスイッチの初期状態
* テーマが保存されているか
* テーマが変更できるか

## その他