### PR TITLE
#27 詳細ページの詳細要素のアイコンを大きくする

### DIFF
--- a/lib/presentation/detail/widget/detail_element.dart
+++ b/lib/presentation/detail/widget/detail_element.dart
@@ -82,7 +82,7 @@ Widget detailElement(
       children: [
         CircleAvatar(
           backgroundColor: iconBackgroundColor,
-          child: Icon(icon, size: 20, color: iconColor),
+          child: Icon(icon, size: 25, color: iconColor),
         ),
         const SizedBox(width: 12),
         Text(elementLabel, style: const TextStyle(fontSize: 16)),


### PR DESCRIPTION
## 概要
#27 対応
タイトルの通り

## スクリーンショット
|before|after|
|-|-|
|<img width="359" alt="スクリーンショット 2023-04-05 17 30 54" src="https://user-images.githubusercontent.com/87256037/230027347-7ca2968c-59f7-4d8c-af48-ad353aa8fd2e.png">|<img width="347" alt="スクリーンショット 2023-04-05 17 31 11" src="https://user-images.githubusercontent.com/87256037/230027401-97c635fa-87dc-43ba-ab40-ce8475d99c7c.png">|


## その他