### PR TITLE
#25 詳細ページにギットハブのリンクへ飛べるテキストを表示する

### DIFF
--- a/integration_test/input_search_test.dart
+++ b/integration_test/input_search_test.dart
@@ -3,8 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:yumemi_flutter_repo_search/main.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
+import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 
 import '../test/repository/repository_mock_data.dart';
 import '../test/repository/repository_mock_test.mocks.dart';
@@ -15,6 +17,8 @@ void main() {
 
   testWidgets('入力→結果が表示される→タップで画面遷移→遷移後に情報が表示されているか',
       (WidgetTester tester) async {
+    //モックのデータをshared_preferencesにセットしておかないといけない
+    SharedPreferences.setMockInitialValues({});
     const data = RepositoryMockData.jsonData;
     final mockClient = MockClient();
     when(mockClient.get(any)).thenAnswer((_) async => http.Response(data, 200));
@@ -23,6 +27,10 @@ void main() {
       ProviderScope(overrides: [
         //mock clientでDI
         httpClientProvider.overrideWithValue(mockClient),
+        //sharedPreferencesを初回で上書き
+        sharedPreferencesProvider.overrideWithValue(
+          await SharedPreferences.getInstance(),
+        ),
       ], child: const MyApp()),
     );
 
@@ -71,5 +79,6 @@ void main() {
     expect(find.byKey(const Key('watch')), findsOneWidget);
     expect(find.byKey(const Key('fork')), findsOneWidget);
     expect(find.byKey(const Key('issue')), findsOneWidget);
+    expect(find.byKey(const Key('viewOnGithub')), findsOneWidget);
   });
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -14,6 +14,8 @@ PODS:
   - sqflite (0.0.2):
     - Flutter
     - FMDB (>= 2.7.5)
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,6 +23,7 @@ DEPENDENCIES:
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -37,6 +40,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/ios"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
@@ -45,6 +50,7 @@ SPEC CHECKSUMS:
   path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
   shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
+  url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 

--- a/lib/domain/repo_data_model.dart
+++ b/lib/domain/repo_data_model.dart
@@ -27,6 +27,7 @@ class RepoDataItems with _$RepoDataItems {
     required int watchersCount,
     required int forksCount,
     required int openIssuesCount,
+    required String htmlUrl,
     required RepoDataOwner owner,
   }) = _RepoDataItems;
 

--- a/lib/generated/intl/messages_all.dart
+++ b/lib/generated/intl/messages_all.dart
@@ -12,7 +12,6 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';

--- a/lib/generated/intl/messages_all.dart
+++ b/lib/generated/intl/messages_all.dart
@@ -12,6 +12,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -44,6 +44,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchPageTitle":
             MessageLookupByLibrary.simpleMessage("GitHub Search"),
         "star": MessageLookupByLibrary.simpleMessage("Star"),
+        "viewOnGitHub": MessageLookupByLibrary.simpleMessage("View On GitHub"),
         "watch": MessageLookupByLibrary.simpleMessage("Watch")
       };
 }

--- a/lib/generated/intl/messages_ja.dart
+++ b/lib/generated/intl/messages_ja.dart
@@ -40,6 +40,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "result": MessageLookupByLibrary.simpleMessage("件"),
         "searchPageTitle": MessageLookupByLibrary.simpleMessage("GitHubサーチ"),
         "star": MessageLookupByLibrary.simpleMessage("スター"),
+        "viewOnGitHub": MessageLookupByLibrary.simpleMessage("ギットハブ上で見る"),
         "watch": MessageLookupByLibrary.simpleMessage("ウォッチ")
       };
 }

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+
 import 'package:flutter/material.dart';
+
 import 'package:intl/intl.dart';
+
 import 'intl/messages_all.dart';
 
 // **************************************************************************

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1,9 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-
 import 'package:flutter/material.dart';
-
 import 'package:intl/intl.dart';
-
 import 'intl/messages_all.dart';
 
 // **************************************************************************
@@ -138,6 +135,16 @@ class S {
     return Intl.message(
       'Issue',
       name: 'issue',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `View On GitHub`
+  String get viewOnGitHub {
+    return Intl.message(
+      'View On GitHub',
+      name: 'viewOnGitHub',
       desc: '',
       args: [],
     );

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -8,6 +8,7 @@
   "watch": "Watch",
   "fork": "Fork",
   "issue": "Issue",
+  "viewOnGitHub": "View On GitHub",
   "errorOccurred": "Error Occurred.",
   "errorOccurredDetail": "Please retry later.",
   "networkError": "Network Error.",

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -8,6 +8,7 @@
   "watch": "ウォッチ",
   "fork": "フォーク",
   "issue": "イシュー",
+  "viewOnGitHub": "ギットハブ上で見る",
   "errorOccurred": "エラーが発生しました。",
   "errorOccurredDetail": "時間をおいて再度お試しください。",
   "networkError": "ネットワークエラーです。",

--- a/lib/presentation/detail/detail_page.dart
+++ b/lib/presentation/detail/detail_page.dart
@@ -109,7 +109,7 @@ class DetailPage extends StatelessWidget {
   }
 
   //githubページに飛ばすテキスト
-  Widget githubLinkText(context) {
+  Widget githubLinkText(BuildContext context) {
     return Align(
       alignment: Alignment.centerRight,
       child: GestureDetector(
@@ -123,6 +123,7 @@ class DetailPage extends StatelessWidget {
             decoration: TextDecoration.underline,
             decorationColor: Colors.blueAccent,
           ),
+          key: const Key('viewOnGithub'),
         ),
       ),
     );

--- a/lib/presentation/detail/detail_page.dart
+++ b/lib/presentation/detail/detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:intl/intl.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:yumemi_flutter_repo_search/presentation/detail/widget/detail_element.dart';
 import 'package:yumemi_flutter_repo_search/presentation/detail/widget/hori_repo_header.dart';
@@ -62,7 +63,9 @@ class DetailPage extends StatelessWidget {
                   fork: forksCount,
                   issue: issuesCount,
                 ),
-                const SizedBox(height: 60)
+                const SizedBox(height: 30),
+                githubLinkText(context),
+                const SizedBox(height: 50),
               ],
             ),
           ),
@@ -94,12 +97,46 @@ class DetailPage extends StatelessWidget {
                   fork: forksCount,
                   issue: issuesCount,
                 ),
-                const SizedBox(height: 60)
+                const SizedBox(height: 30),
+                githubLinkText(context),
+                const SizedBox(height: 50),
               ],
             ),
           ),
         ],
       ),
     );
+  }
+
+  //githubページに飛ばすテキスト
+  Widget githubLinkText(context) {
+    return Align(
+      alignment: Alignment.centerRight,
+      child: GestureDetector(
+        onTap: () => _openGitHubUrl(Uri.parse(repoData.htmlUrl)),
+        child: Text(
+          S.of(context).viewOnGitHub,
+          style: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.blueAccent,
+            decoration: TextDecoration.underline,
+            decorationColor: Colors.blueAccent,
+          ),
+        ),
+      ),
+    );
+  }
+
+  //GitHubのリンク先に飛ばす
+  Future<void> _openGitHubUrl(Uri url) async {
+    if (await canLaunchUrl(url)) {
+      await launchUrl(
+        url,
+        mode: LaunchMode.inAppWebView,
+      );
+    } else {
+      throw Exception('このURLにはアクセスできません');
+    }
   }
 }

--- a/lib/presentation/detail/widget/detail_element.dart
+++ b/lib/presentation/detail/widget/detail_element.dart
@@ -62,7 +62,6 @@ class DetailElement extends StatelessWidget {
           iconColor: Colors.white,
           key: const Key('issue'),
         ),
-        const SizedBox(height: 60)
       ],
     );
   }

--- a/lib/presentation/detail/widget/ver_repo_header.dart
+++ b/lib/presentation/detail/widget/ver_repo_header.dart
@@ -41,7 +41,7 @@ class VerRepoHeader extends StatelessWidget {
           Text(
             repoData.description ?? 'No Description',
             style: Theme.of(context).textTheme.titleSmall,
-            key: const Key('repoNameOnDetailPage'),
+            key: const Key('repoDetailOnDetailPage'),
           ),
         ],
       ),

--- a/lib/presentation/search/widget/search_app_bar.dart
+++ b/lib/presentation/search/widget/search_app_bar.dart
@@ -24,6 +24,7 @@ class SearchAppBar extends ConsumerWidget implements PreferredSizeWidget {
     //theme切り替えのプロバイダ
     final themeSelector = ref.read(themeModeProvider.notifier);
     return AppBar(
+      key: const Key('searchPageAppBar'),
       title: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -881,6 +881,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "75f2846facd11168d007529d6cd8fcb2b750186bea046af9711f10b907e1587e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.10"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: dd729390aa936bf1bdf5cd1bc7468ff340263f80a2c4f569416507667de8e3c8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.26"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "3dedc66ca3c0bef9e6a93c0999aee102556a450afcc1b7bcfeace7a424927d92"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "206fb8334a700ef7754d6a9ed119e7349bc830448098f21a69bf1b4ed038cabc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.4"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "0ef2b4f97942a16523e51256b799e9aa1843da6c60c55eefbfa9dbc2dcb8331a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.4"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "6c9ca697a5ae218ce56cece69d46128169a58aa8653c1b01d26fcd4aad8c4370"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "81fe91b6c4f84f222d186a9d23c73157dc4c8e1c71489c4d08be1ad3b228f1aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.16"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: a83ba3607a507758669cfafb03f9de09bf6e6280c14d9b9cb18f013e406dcacd
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   flutter_switch: ^0.3.2
   shared_preferences: ^2.1.0
   device_preview: ^1.1.0
+  url_launcher: ^6.1.10
 
 dev_dependencies:
   flutter_test:

--- a/test/presentation/input_search_test.dart
+++ b/test/presentation/input_search_test.dart
@@ -172,6 +172,7 @@ void main() {
       expect(find.byKey(const Key('watch')), findsOneWidget);
       expect(find.byKey(const Key('fork')), findsOneWidget);
       expect(find.byKey(const Key('issue')), findsOneWidget);
+      expect(find.byKey(const Key('viewOnGithub')), findsOneWidget);
     });
   });
 }

--- a/test/repository/repository_mock_data.dart
+++ b/test/repository/repository_mock_data.dart
@@ -11,6 +11,7 @@ class RepositoryMockData {
       "watchers_count": 150088,
       "forks_count": 24628,
       "open_issues_count": 11582,
+      "html_url": "https://github.com/flutter/flutter",
       "owner": {
         "avatar_url": "https://avatars.githubusercontent.com/u/14101776?v=4"
       }


### PR DESCRIPTION
## 概要
#25 対応
* 詳細ページ下部にギットハブのリンクへのテキストを表示した
* テストが通るように修正した
* リンク用にデータモデルを更新した


## スクリーンショット
https://user-images.githubusercontent.com/87256037/230059067-08c2c92d-0016-48f8-8ade-34f897d45215.mov


## テスト
mockのデータにギットハブのURLを追加
テストが通るように修正

## その他