### PR TITLE
#57 テストで使うキーは@visibleForTestingをつけてテストのみで参照できるようにする

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,7 +4,7 @@ include: package:flutter_lints/flutter.yaml
 linter:
 
   rules:
-     prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 analyzer:
   exclude:
@@ -14,3 +14,4 @@ analyzer:
   
   errors:
     invalid_annotation_target: ignore
+    invalid_use_of_visible_for_testing_member: error

--- a/integration_test/input_search_test.dart
+++ b/integration_test/input_search_test.dart
@@ -1,10 +1,16 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:yumemi_flutter_repo_search/main.dart';
+import 'package:yumemi_flutter_repo_search/presentation/detail/detail_page.dart';
+import 'package:yumemi_flutter_repo_search/presentation/detail/widget/detail_element.dart';
+import 'package:yumemi_flutter_repo_search/presentation/detail/widget/ver_repo_header.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/list_item.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/result_list_view.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_app_bar.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
 import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 
@@ -35,9 +41,9 @@ void main() {
     );
 
     //検索ページのアップバーが表示されているか
-    expect(find.byKey(const Key('searchPageAppBar')), findsOneWidget);
+    expect(find.byKey(SearchAppBar.searchPageAppBarKey), findsOneWidget);
 
-    final formField = find.byKey(const Key('inputForm'));
+    final formField = find.byKey(SearchBar.inputFormKey);
 
     //flutterと入力して検索する
     await tester.enterText(formField, 'flutter');
@@ -46,39 +52,37 @@ void main() {
     await tester.testTextInput.receiveAction(TextInputAction.search);
 
     //リストが描画される
-    await tester.pump(const Duration(seconds: 3));
-    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
 
-    //"flutter/flutter" と言う文字が見つかるか
+    //"flutter/flutter" の文字が見つかるか
     final tapTarget = find.text('flutter/flutter');
     expect(tapTarget, findsOneWidget);
     //ユーザーアイコンが表示されるか
-    expect(find.byKey(const Key('userImageOnListView')), findsWidgets);
+    expect(find.byKey(ListItem.userImageOnListViewKey), findsWidgets);
     //検索結果数が表示されるか
-    expect(find.byKey(const Key('resultCount')), findsOneWidget);
+    expect(find.byKey(ResultListview.resultCountKey), findsOneWidget);
 
     //リストをタップ→詳細ページに遷移
     await tester.tap(tapTarget);
 
     //画面遷移するまで待つ
-    await tester.pump(const Duration(seconds: 2));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     //詳細ページのアップバーが表示されるか
-    expect(find.byKey(const Key('detailPageAppBar')), findsOneWidget);
+    expect(find.byKey(DetailPage.detailPageAppBarKey), findsOneWidget);
     //ユーザーのアイコンが表示されるか
-    expect(find.byKey(const Key('userImageOnDetailPage')), findsOneWidget);
+    expect(find.byKey(VerRepoHeader.userImageOnDetailPageKey), findsOneWidget);
     //詳細ページのレポジトリ名が表示される
-    expect(find.byKey(const Key('repoNameOnDetailPage')), findsOneWidget);
-    //詳細ページのレポジトリ詳細が表示される
-    expect(find.byKey(const Key('repoDetailOnDetailPage')), findsOneWidget);
+    expect(find.byKey(VerRepoHeader.repoNameOnDetailPageKey), findsOneWidget);
+    // //詳細ページのレポジトリ詳細が表示される
+    expect(find.byKey(VerRepoHeader.repoDetailOnDetailPageKey), findsOneWidget);
 
     //その他の情報が表示されるか
-    expect(find.byKey(const Key('language')), findsOneWidget);
-    expect(find.byKey(const Key('star')), findsOneWidget);
-    expect(find.byKey(const Key('watch')), findsOneWidget);
-    expect(find.byKey(const Key('fork')), findsOneWidget);
-    expect(find.byKey(const Key('issue')), findsOneWidget);
-    expect(find.byKey(const Key('viewOnGithub')), findsOneWidget);
+    expect(find.byKey(DetailElement.languageKey), findsOneWidget);
+    expect(find.byKey(DetailElement.starKey), findsOneWidget);
+    expect(find.byKey(DetailElement.watchKey), findsOneWidget);
+    expect(find.byKey(DetailElement.forkKey), findsOneWidget);
+    expect(find.byKey(DetailElement.issueKey), findsOneWidget);
+    expect(find.byKey(DetailPage.viewOnGithubKey), findsOneWidget);
   });
 }

--- a/integration_test/input_search_test.dart
+++ b/integration_test/input_search_test.dart
@@ -46,13 +46,15 @@ void main() {
     final formField = find.byKey(SearchBar.inputFormKey);
 
     //flutterと入力して検索する
-    await tester.enterText(formField, 'flutter');
     await tester.tap(formField);
+    await tester.enterText(formField, 'flutter');
     //検索ボタンを押す
     await tester.testTextInput.receiveAction(TextInputAction.search);
 
-    //リストが描画される
-    await tester.pump(const Duration(seconds: 2));
+    //shimmerが描画される
+    await tester.pump();
+    //リストの描画
+    await tester.pump();
 
     //"flutter/flutter" の文字が見つかるか
     final tapTarget = find.text('flutter/flutter');

--- a/integration_test/input_search_test.dart
+++ b/integration_test/input_search_test.dart
@@ -41,7 +41,7 @@ void main() {
     );
 
     //検索ページのアップバーが表示されているか
-    expect(find.byKey(SearchAppBar.searchPageAppBarKey), findsOneWidget);
+    expect(find.byKey(SearchAppBar.appBarKey), findsOneWidget);
 
     final formField = find.byKey(SearchBar.inputFormKey);
 
@@ -58,7 +58,7 @@ void main() {
     final tapTarget = find.text('flutter/flutter');
     expect(tapTarget, findsOneWidget);
     //ユーザーアイコンが表示されるか
-    expect(find.byKey(ListItem.userImageOnListViewKey), findsWidgets);
+    expect(find.byKey(ListItem.userImageKey), findsWidgets);
     //検索結果数が表示されるか
     expect(find.byKey(ResultListview.resultCountKey), findsOneWidget);
 
@@ -69,13 +69,13 @@ void main() {
     await tester.pumpAndSettle();
 
     //詳細ページのアップバーが表示されるか
-    expect(find.byKey(DetailPage.detailPageAppBarKey), findsOneWidget);
+    expect(find.byKey(DetailPage.appBarKey), findsOneWidget);
     //ユーザーのアイコンが表示されるか
-    expect(find.byKey(VerRepoHeader.userImageOnDetailPageKey), findsOneWidget);
+    expect(find.byKey(VerRepoHeader.userImageKey), findsOneWidget);
     //詳細ページのレポジトリ名が表示される
-    expect(find.byKey(VerRepoHeader.repoNameOnDetailPageKey), findsOneWidget);
+    expect(find.byKey(VerRepoHeader.repoNameKey), findsOneWidget);
     // //詳細ページのレポジトリ詳細が表示される
-    expect(find.byKey(VerRepoHeader.repoDetailOnDetailPageKey), findsOneWidget);
+    expect(find.byKey(VerRepoHeader.repoDetailKey), findsOneWidget);
 
     //その他の情報が表示されるか
     expect(find.byKey(DetailElement.languageKey), findsOneWidget);

--- a/lib/presentation/detail/detail_page.dart
+++ b/lib/presentation/detail/detail_page.dart
@@ -16,7 +16,7 @@ class DetailPage extends StatelessWidget {
 
   //テスト用のKEY
   @visibleForTesting
-  static final detailPageAppBarKey = UniqueKey();
+  static final appBarKey = UniqueKey();
   @visibleForTesting
   static final viewOnGithubKey = UniqueKey();
 
@@ -32,7 +32,7 @@ class DetailPage extends StatelessWidget {
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
         title: Text(S.of(context).detailPageTitle),
-        key: detailPageAppBarKey,
+        key: appBarKey,
       ),
       body: LayoutBuilder(
         builder: (context, constraints) {

--- a/lib/presentation/detail/detail_page.dart
+++ b/lib/presentation/detail/detail_page.dart
@@ -14,6 +14,12 @@ class DetailPage extends StatelessWidget {
 
   final RepoDataItems repoData;
 
+  //テスト用のKEY
+  @visibleForTesting
+  static final detailPageAppBarKey = UniqueKey();
+  @visibleForTesting
+  static final viewOnGithubKey = UniqueKey();
+
   @override
   Widget build(BuildContext context) {
     // データの数をカンマ区切りで表示
@@ -25,16 +31,18 @@ class DetailPage extends StatelessWidget {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
-        title: Text(S.of(context).detailPageTitle),
-        key: const Key('detailPageAppBar'),
+        title: Text(S
+            .of(context)
+            .detailPageTitle),
+        key: detailPageAppBarKey,
       ),
       body: LayoutBuilder(
         builder: (context, constraints) {
           return constraints.maxWidth < constraints.maxHeight
               ? verBody(
-                  context, starsCount, watchersCount, forksCount, issuesCount)
+              context, starsCount, watchersCount, forksCount, issuesCount)
               : horiBody(
-                  context, starsCount, watchersCount, forksCount, issuesCount);
+              context, starsCount, watchersCount, forksCount, issuesCount);
         },
       ),
     );
@@ -43,7 +51,10 @@ class DetailPage extends StatelessWidget {
   Widget verBody(BuildContext context, String starsCount, String watchersCount,
       String forksCount, String issuesCount) {
     //画面サイズ取得
-    final widthSize = MediaQuery.of(context).size.width;
+    final widthSize = MediaQuery
+        .of(context)
+        .size
+        .width;
     return SingleChildScrollView(
       child: Column(
         children: [
@@ -77,7 +88,10 @@ class DetailPage extends StatelessWidget {
   Widget horiBody(BuildContext context, String starsCount, String watchersCount,
       String forksCount, String issuesCount) {
     //画面サイズ取得
-    final widthSize = MediaQuery.of(context).size.width;
+    final widthSize = MediaQuery
+        .of(context)
+        .size
+        .width;
     return SingleChildScrollView(
       child: Column(
         children: [
@@ -87,7 +101,7 @@ class DetailPage extends StatelessWidget {
           //リポジトリのスター数などの要素
           Container(
             padding:
-                EdgeInsets.symmetric(vertical: 16, horizontal: widthSize * 0.1),
+            EdgeInsets.symmetric(vertical: 16, horizontal: widthSize * 0.1),
             child: Column(
               children: [
                 DetailElement(
@@ -115,7 +129,9 @@ class DetailPage extends StatelessWidget {
       child: GestureDetector(
         onTap: () => _openGitHubUrl(Uri.parse(repoData.htmlUrl)),
         child: Text(
-          S.of(context).viewOnGitHub,
+          S
+              .of(context)
+              .viewOnGitHub,
           style: const TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.bold,
@@ -123,7 +139,7 @@ class DetailPage extends StatelessWidget {
             decoration: TextDecoration.underline,
             decorationColor: Colors.blueAccent,
           ),
-          key: const Key('viewOnGithub'),
+          key: viewOnGithubKey,
         ),
       ),
     );

--- a/lib/presentation/detail/detail_page.dart
+++ b/lib/presentation/detail/detail_page.dart
@@ -31,18 +31,16 @@ class DetailPage extends StatelessWidget {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
-        title: Text(S
-            .of(context)
-            .detailPageTitle),
+        title: Text(S.of(context).detailPageTitle),
         key: detailPageAppBarKey,
       ),
       body: LayoutBuilder(
         builder: (context, constraints) {
           return constraints.maxWidth < constraints.maxHeight
               ? verBody(
-              context, starsCount, watchersCount, forksCount, issuesCount)
+                  context, starsCount, watchersCount, forksCount, issuesCount)
               : horiBody(
-              context, starsCount, watchersCount, forksCount, issuesCount);
+                  context, starsCount, watchersCount, forksCount, issuesCount);
         },
       ),
     );
@@ -51,10 +49,7 @@ class DetailPage extends StatelessWidget {
   Widget verBody(BuildContext context, String starsCount, String watchersCount,
       String forksCount, String issuesCount) {
     //画面サイズ取得
-    final widthSize = MediaQuery
-        .of(context)
-        .size
-        .width;
+    final widthSize = MediaQuery.of(context).size.width;
     return SingleChildScrollView(
       child: Column(
         children: [
@@ -88,10 +83,7 @@ class DetailPage extends StatelessWidget {
   Widget horiBody(BuildContext context, String starsCount, String watchersCount,
       String forksCount, String issuesCount) {
     //画面サイズ取得
-    final widthSize = MediaQuery
-        .of(context)
-        .size
-        .width;
+    final widthSize = MediaQuery.of(context).size.width;
     return SingleChildScrollView(
       child: Column(
         children: [
@@ -101,7 +93,7 @@ class DetailPage extends StatelessWidget {
           //リポジトリのスター数などの要素
           Container(
             padding:
-            EdgeInsets.symmetric(vertical: 16, horizontal: widthSize * 0.1),
+                EdgeInsets.symmetric(vertical: 16, horizontal: widthSize * 0.1),
             child: Column(
               children: [
                 DetailElement(
@@ -129,9 +121,7 @@ class DetailPage extends StatelessWidget {
       child: GestureDetector(
         onTap: () => _openGitHubUrl(Uri.parse(repoData.htmlUrl)),
         child: Text(
-          S
-              .of(context)
-              .viewOnGitHub,
+          S.of(context).viewOnGitHub,
           style: const TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.bold,

--- a/lib/presentation/detail/widget/detail_element.dart
+++ b/lib/presentation/detail/widget/detail_element.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'package:yumemi_flutter_repo_search/presentation/detail/widget/hori_repo_header.dart';
 import '../../../generated/l10n.dart';
 
 class DetailElement extends StatelessWidget {

--- a/lib/presentation/detail/widget/detail_element.dart
+++ b/lib/presentation/detail/widget/detail_element.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_repo_search/presentation/detail/widget/hori_repo_header.dart';
 
 import '../../../generated/l10n.dart';
 
@@ -18,6 +19,18 @@ class DetailElement extends StatelessWidget {
   final String fork;
   final String issue;
 
+  //テスト用KEY
+  @visibleForTesting
+  static final languageKey = UniqueKey();
+  @visibleForTesting
+  static final starKey = UniqueKey();
+  @visibleForTesting
+  static final watchKey = UniqueKey();
+  @visibleForTesting
+  static final forkKey = UniqueKey();
+  @visibleForTesting
+  static final issueKey = UniqueKey();
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -28,7 +41,7 @@ class DetailElement extends StatelessWidget {
           elementData: language ?? 'No Language',
           iconBackgroundColor: Colors.blueAccent,
           iconColor: Colors.white,
-          key: const Key('language'),
+          key: languageKey,
         ),
         detailElement(
           icon: Icons.star_outline,
@@ -36,7 +49,7 @@ class DetailElement extends StatelessWidget {
           elementData: star,
           iconBackgroundColor: Colors.yellowAccent,
           iconColor: Colors.black87,
-          key: const Key('star'),
+          key: starKey,
         ),
         detailElement(
           icon: Icons.remove_red_eye_outlined,
@@ -44,7 +57,7 @@ class DetailElement extends StatelessWidget {
           elementData: watch,
           iconBackgroundColor: Colors.brown,
           iconColor: Colors.white,
-          key: const Key('watch'),
+          key: watchKey,
         ),
         detailElement(
           icon: Icons.fork_right_sharp,
@@ -52,7 +65,7 @@ class DetailElement extends StatelessWidget {
           elementData: fork,
           iconBackgroundColor: Colors.purpleAccent,
           iconColor: Colors.white,
-          key: const Key('fork'),
+          key: forkKey,
         ),
         detailElement(
           icon: Icons.info_outline,
@@ -60,7 +73,7 @@ class DetailElement extends StatelessWidget {
           elementData: issue,
           iconBackgroundColor: Colors.green,
           iconColor: Colors.white,
-          key: const Key('issue'),
+          key: issueKey,
         ),
       ],
     );

--- a/lib/presentation/detail/widget/detail_element.dart
+++ b/lib/presentation/detail/widget/detail_element.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:yumemi_flutter_repo_search/presentation/detail/widget/hori_repo_header.dart';
 
+import 'package:yumemi_flutter_repo_search/presentation/detail/widget/hori_repo_header.dart';
 import '../../../generated/l10n.dart';
 
 class DetailElement extends StatelessWidget {

--- a/lib/presentation/detail/widget/hori_repo_header.dart
+++ b/lib/presentation/detail/widget/hori_repo_header.dart
@@ -10,6 +10,14 @@ class HoriRepoHeader extends StatelessWidget {
 
   final RepoDataItems repoData;
 
+  //テスト用KEY
+  @visibleForTesting
+  static final userImageOnDetailPageKey = UniqueKey();
+  @visibleForTesting
+  static final repoDetailOnDetailPageKey = UniqueKey();
+  @visibleForTesting
+  static final repoNameOnDetailPageKey = UniqueKey();
+
   @override
   Widget build(BuildContext context) {
     final widthSize = MediaQuery.of(context).size.width;
@@ -27,7 +35,7 @@ class HoriRepoHeader extends StatelessWidget {
                 height: 120,
                 placeholder: (_, __) => const UserIconShimmer(),
                 errorWidget: (_, __, ___) => const Icon(Icons.error, size: 50),
-                key: const Key('userImageOnDetailPage'),
+                key: userImageOnDetailPageKey,
               ),
             ),
           ),
@@ -39,13 +47,13 @@ class HoriRepoHeader extends StatelessWidget {
                 Text(
                   repoData.fullName,
                   style: Theme.of(context).textTheme.titleLarge,
-                  key: const Key('repoNameOnDetailPage'),
+                  key: repoNameOnDetailPageKey,
                 ),
                 const SizedBox(height: 10),
                 Text(
                   repoData.description ?? 'No Description',
                   style: Theme.of(context).textTheme.titleSmall,
-                  key: const Key('repoDetailOnDetailPage'),
+                  key: repoDetailOnDetailPageKey,
                 ),
               ],
             ),

--- a/lib/presentation/detail/widget/hori_repo_header.dart
+++ b/lib/presentation/detail/widget/hori_repo_header.dart
@@ -12,11 +12,11 @@ class HoriRepoHeader extends StatelessWidget {
 
   //テスト用KEY
   @visibleForTesting
-  static final userImageOnDetailPageKey = UniqueKey();
+  static final userImageKey = UniqueKey();
   @visibleForTesting
-  static final repoDetailOnDetailPageKey = UniqueKey();
+  static final repoDetailKey = UniqueKey();
   @visibleForTesting
-  static final repoNameOnDetailPageKey = UniqueKey();
+  static final repoNameKey = UniqueKey();
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +35,7 @@ class HoriRepoHeader extends StatelessWidget {
                 height: 120,
                 placeholder: (_, __) => const UserIconShimmer(),
                 errorWidget: (_, __, ___) => const Icon(Icons.error, size: 50),
-                key: userImageOnDetailPageKey,
+                key: userImageKey,
               ),
             ),
           ),
@@ -47,13 +47,13 @@ class HoriRepoHeader extends StatelessWidget {
                 Text(
                   repoData.fullName,
                   style: Theme.of(context).textTheme.titleLarge,
-                  key: repoNameOnDetailPageKey,
+                  key: repoNameKey,
                 ),
                 const SizedBox(height: 10),
                 Text(
                   repoData.description ?? 'No Description',
                   style: Theme.of(context).textTheme.titleSmall,
-                  key: repoDetailOnDetailPageKey,
+                  key: repoDetailKey,
                 ),
               ],
             ),

--- a/lib/presentation/detail/widget/ver_repo_header.dart
+++ b/lib/presentation/detail/widget/ver_repo_header.dart
@@ -12,11 +12,11 @@ class VerRepoHeader extends StatelessWidget {
 
   //テスト用KEY
   @visibleForTesting
-  static final userImageOnDetailPageKey = UniqueKey();
+  static final userImageKey = UniqueKey();
   @visibleForTesting
-  static final repoDetailOnDetailPageKey = UniqueKey();
+  static final repoDetailKey = UniqueKey();
   @visibleForTesting
-  static final repoNameOnDetailPageKey = UniqueKey();
+  static final repoNameKey = UniqueKey();
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +34,7 @@ class VerRepoHeader extends StatelessWidget {
                 height: 120,
                 placeholder: (_, __) => const UserIconShimmer(),
                 errorWidget: (_, __, ___) => const Icon(Icons.error, size: 50),
-                key: userImageOnDetailPageKey,
+                key: userImageKey,
               ),
             ),
           ),
@@ -43,13 +43,13 @@ class VerRepoHeader extends StatelessWidget {
             child: Text(
               repoData.fullName,
               style: Theme.of(context).textTheme.titleLarge,
-              key: repoNameOnDetailPageKey,
+              key: repoNameKey,
             ),
           ),
           Text(
             repoData.description ?? 'No Description',
             style: Theme.of(context).textTheme.titleSmall,
-            key: repoDetailOnDetailPageKey,
+            key: repoDetailKey,
           ),
         ],
       ),

--- a/lib/presentation/detail/widget/ver_repo_header.dart
+++ b/lib/presentation/detail/widget/ver_repo_header.dart
@@ -10,6 +10,14 @@ class VerRepoHeader extends StatelessWidget {
 
   final RepoDataItems repoData;
 
+  //テスト用KEY
+  @visibleForTesting
+  static final userImageOnDetailPageKey = UniqueKey();
+  @visibleForTesting
+  static final repoDetailOnDetailPageKey = UniqueKey();
+  @visibleForTesting
+  static final repoNameOnDetailPageKey = UniqueKey();
+
   @override
   Widget build(BuildContext context) {
     final widthSize = MediaQuery.of(context).size.width;
@@ -26,7 +34,7 @@ class VerRepoHeader extends StatelessWidget {
                 height: 120,
                 placeholder: (_, __) => const UserIconShimmer(),
                 errorWidget: (_, __, ___) => const Icon(Icons.error, size: 50),
-                key: const Key('userImageOnDetailPage'),
+                key: userImageOnDetailPageKey,
               ),
             ),
           ),
@@ -35,13 +43,13 @@ class VerRepoHeader extends StatelessWidget {
             child: Text(
               repoData.fullName,
               style: Theme.of(context).textTheme.titleLarge,
-              key: const Key('repoNameOnDetailPage'),
+              key: repoNameOnDetailPageKey,
             ),
           ),
           Text(
             repoData.description ?? 'No Description',
             style: Theme.of(context).textTheme.titleSmall,
-            key: const Key('repoDetailOnDetailPage'),
+            key: repoDetailOnDetailPageKey,
           ),
         ],
       ),

--- a/lib/presentation/search/widget/error/error_widget.dart
+++ b/lib/presentation/search/widget/error/error_widget.dart
@@ -6,12 +6,15 @@ import 'error_component.dart';
 class EnterTextView extends StatelessWidget {
   const EnterTextView({Key? key}) : super(key: key);
 
+  @visibleForTesting
+  static final enterTextViewKey = UniqueKey();
+
   @override
   Widget build(BuildContext context) {
     return ErrorComponent(
       lottieFile: 'assets/lottie_animation/20180-guy-typing.json',
       errorTitle: S.of(context).enterText,
-      key: const Key('enterTextView'),
+      key: enterTextViewKey,
     );
   }
 }
@@ -19,13 +22,16 @@ class EnterTextView extends StatelessWidget {
 class NetworkErrorView extends StatelessWidget {
   const NetworkErrorView({Key? key}) : super(key: key);
 
+  @visibleForTesting
+  static final networkErrorViewKey = UniqueKey();
+
   @override
   Widget build(BuildContext context) {
     return ErrorComponent(
       lottieFile: 'assets/lottie_animation/118789-no-internet.json',
       errorTitle: S.of(context).networkError,
       errorDetail: S.of(context).networkErrorDetail,
-      key: const Key('networkErrorView'),
+      key: networkErrorViewKey,
     );
   }
 }
@@ -34,13 +40,16 @@ class NetworkErrorView extends StatelessWidget {
 class ErrorView extends StatelessWidget {
   const ErrorView({Key? key}) : super(key: key);
 
+  @visibleForTesting
+  static final errorViewKey = UniqueKey();
+
   @override
   Widget build(BuildContext context) {
     return ErrorComponent(
       lottieFile: 'assets/lottie_animation/99345-error.json',
       errorTitle: S.of(context).errorOccurred,
       errorDetail: S.of(context).errorOccurredDetail,
-      key: const Key('errorView'),
+      key: errorViewKey,
     );
   }
 }
@@ -48,13 +57,16 @@ class ErrorView extends StatelessWidget {
 class NoResultView extends StatelessWidget {
   const NoResultView({Key? key}) : super(key: key);
 
+  @visibleForTesting
+  static final noResultViewKey = UniqueKey();
+
   @override
   Widget build(BuildContext context) {
     return ErrorComponent(
       lottieFile: 'assets/lottie_animation/106964-shake-a-empty-box.json',
       errorTitle: S.of(context).noResult,
       errorDetail: S.of(context).noResultDetail,
-      key: const Key('noResultView'),
+      key: noResultViewKey,
     );
   }
 }

--- a/lib/presentation/search/widget/list_item.dart
+++ b/lib/presentation/search/widget/list_item.dart
@@ -12,6 +12,9 @@ import 'error/error_widget.dart';
 class ListItem extends ConsumerWidget {
   const ListItem({Key? key}) : super(key: key);
 
+  @visibleForTesting
+  static final userImageOnListViewKey = UniqueKey();
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final index = ref.read(listIndexProvider);
@@ -21,56 +24,57 @@ class ListItem extends ConsumerWidget {
       top: false,
       bottom: false,
       child: repoData.when(
-        data: (data) => GestureDetector(
-          //画像部分もタップできるように全体をGestureDetectorで囲む
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => DetailPage(repoData: data),
-              ),
-            );
-          },
-          child: Row(
-            children: [
-              const SizedBox(width: 16), //16はListTileの横paddingと一緒の値
-              //ListTileのleadingで画像を表示すると、縦が真ん中にならなかったのでこの方法で表示するようにする
-              Hero(
-                tag: data,
-                //user image icon
-                child: ClipOval(
-                  child: CachedNetworkImage(
-                    width: 60,
-                    height: 60,
-                    imageUrl: data.owner.avatarUrl,
-                    placeholder: (_, __) => const UserIconShimmer(),
-                    errorWidget: (_, __, ___) =>
-                        const Icon(Icons.error, size: 50),
-                    key: const Key('userImageOnListView'),
+        data: (data) =>
+            GestureDetector(
+              //画像部分もタップできるように全体をGestureDetectorで囲む
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => DetailPage(repoData: data),
                   ),
-                ),
-              ),
-              // list tile
-              Expanded(
-                child: ListTile(
-                  title: Padding(
-                    padding: const EdgeInsets.only(bottom: 5),
-                    child: Text(
-                      data.fullName,
-                      style: const TextStyle(
-                          fontSize: 16, fontWeight: FontWeight.bold),
+                );
+              },
+              child: Row(
+                children: [
+                  const SizedBox(width: 16), //16はListTileの横paddingと一緒の値
+                  //ListTileのleadingで画像を表示すると、縦が真ん中にならなかったのでこの方法で表示するようにする
+                  Hero(
+                    tag: data,
+                    //user image icon
+                    child: ClipOval(
+                      child: CachedNetworkImage(
+                        width: 60,
+                        height: 60,
+                        imageUrl: data.owner.avatarUrl,
+                        placeholder: (_, __) => const UserIconShimmer(),
+                        errorWidget: (_, __, ___) =>
+                        const Icon(Icons.error, size: 50),
+                        key: userImageOnListViewKey,
+                      ),
                     ),
                   ),
-                  subtitle: Text(
-                    data.description ?? 'No Description',
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 3,
+                  // list tile
+                  Expanded(
+                    child: ListTile(
+                      title: Padding(
+                        padding: const EdgeInsets.only(bottom: 5),
+                        child: Text(
+                          data.fullName,
+                          style: const TextStyle(
+                              fontSize: 16, fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                      subtitle: Text(
+                        data.description ?? 'No Description',
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 3,
+                      ),
+                    ),
                   ),
-                ),
+                ],
               ),
-            ],
-          ),
-        ),
+            ),
         loading: () => const ListItemShimmer(),
         error: (e, _) {
           if (e == 'No Keywords') {

--- a/lib/presentation/search/widget/list_item.dart
+++ b/lib/presentation/search/widget/list_item.dart
@@ -14,7 +14,7 @@ class ListItem extends ConsumerWidget {
   const ListItem({Key? key}) : super(key: key);
 
   @visibleForTesting
-  static final userImageOnListViewKey = UniqueKey();
+  static final userImageKey = UniqueKey();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -50,7 +50,7 @@ class ListItem extends ConsumerWidget {
                     placeholder: (_, __) => const UserIconShimmer(),
                     errorWidget: (_, __, ___) =>
                         const Icon(Icons.error, size: 50),
-                    key: userImageOnListViewKey,
+                    key: userImageKey,
                   ),
                 ),
               ),

--- a/lib/presentation/search/widget/list_item.dart
+++ b/lib/presentation/search/widget/list_item.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:yumemi_flutter_repo_search/domain/error.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/list_item_shimmer.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/user_icon_shimmer.dart';
 import '../../controller/controllers.dart';
@@ -24,62 +25,61 @@ class ListItem extends ConsumerWidget {
       top: false,
       bottom: false,
       child: repoData.when(
-        data: (data) =>
-            GestureDetector(
-              //画像部分もタップできるように全体をGestureDetectorで囲む
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => DetailPage(repoData: data),
-                  ),
-                );
-              },
-              child: Row(
-                children: [
-                  const SizedBox(width: 16), //16はListTileの横paddingと一緒の値
-                  //ListTileのleadingで画像を表示すると、縦が真ん中にならなかったのでこの方法で表示するようにする
-                  Hero(
-                    tag: data,
-                    //user image icon
-                    child: ClipOval(
-                      child: CachedNetworkImage(
-                        width: 60,
-                        height: 60,
-                        imageUrl: data.owner.avatarUrl,
-                        placeholder: (_, __) => const UserIconShimmer(),
-                        errorWidget: (_, __, ___) =>
-                        const Icon(Icons.error, size: 50),
-                        key: userImageOnListViewKey,
-                      ),
-                    ),
-                  ),
-                  // list tile
-                  Expanded(
-                    child: ListTile(
-                      title: Padding(
-                        padding: const EdgeInsets.only(bottom: 5),
-                        child: Text(
-                          data.fullName,
-                          style: const TextStyle(
-                              fontSize: 16, fontWeight: FontWeight.bold),
-                        ),
-                      ),
-                      subtitle: Text(
-                        data.description ?? 'No Description',
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 3,
-                      ),
-                    ),
-                  ),
-                ],
+        data: (data) => GestureDetector(
+          //画像部分もタップできるように全体をGestureDetectorで囲む
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => DetailPage(repoData: data),
               ),
-            ),
+            );
+          },
+          child: Row(
+            children: [
+              const SizedBox(width: 16), //16はListTileの横paddingと一緒の値
+              //ListTileのleadingで画像を表示すると、縦が真ん中にならなかったのでこの方法で表示するようにする
+              Hero(
+                tag: data,
+                //user image icon
+                child: ClipOval(
+                  child: CachedNetworkImage(
+                    width: 60,
+                    height: 60,
+                    imageUrl: data.owner.avatarUrl,
+                    placeholder: (_, __) => const UserIconShimmer(),
+                    errorWidget: (_, __, ___) =>
+                        const Icon(Icons.error, size: 50),
+                    key: userImageOnListViewKey,
+                  ),
+                ),
+              ),
+              // list tile
+              Expanded(
+                child: ListTile(
+                  title: Padding(
+                    padding: const EdgeInsets.only(bottom: 5),
+                    child: Text(
+                      data.fullName,
+                      style: const TextStyle(
+                          fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  subtitle: Text(
+                    data.description ?? 'No Description',
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 3,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
         loading: () => const ListItemShimmer(),
         error: (e, _) {
-          if (e == 'No Keywords') {
+          if (e is NoTextException) {
             return const EnterTextView();
-          } else if (e == 'Network Error') {
+          } else if (e is NoInternetException) {
             return const NetworkErrorView();
           } else {
             return const ErrorView();

--- a/lib/presentation/search/widget/result_list_view.dart
+++ b/lib/presentation/search/widget/result_list_view.dart
@@ -27,46 +27,44 @@ class ResultListview extends ConsumerWidget {
         alignment: Alignment.bottomCenter,
         children: [
           resultCount.when(
-            data: (totalCount) =>
-            totalCount == 0
-            //検索結果がない場合
+            data: (totalCount) => totalCount == 0
+                //検索結果がない場合
                 ? const NoResultView()
-            //検索結果がある場合
-            //スクロールを検知して、スクロール中は検索結果数を表示しないようにする
+                //検索結果がある場合
+                //スクロールを検知して、スクロール中は検索結果数を表示しないようにする
                 : NotificationListener<ScrollNotification>(
-              onNotification: (notification) {
-                if (notification is ScrollStartNotification) {
-                  // スクロールが開始された場合の処理(非表示)
-                  ref
-                      .read(isResultCountVisibleProvider.notifier)
-                      .update((state) => false);
-                } else if (notification is ScrollEndNotification) {
-                  // スクロールが終了した場合の処理(表示)
-                  ref
-                      .read(isResultCountVisibleProvider.notifier)
-                      .update((state) => true);
-                }
-                return true;
-              },
-              child: ListView.separated(
-                //スクロールでキーボードを閉じるようにした
-                keyboardDismissBehavior:
-                ScrollViewKeyboardDismissBehavior.onDrag,
-                itemCount: totalCount,
-                itemBuilder: (context, index) {
-                  return ProviderScope(
-                    overrides: [
-                      listIndexProvider.overrideWithValue(index)
-                    ],
-                    child: const ListItem(),
-                  );
-                },
-                separatorBuilder: (context, index) =>
-                const Divider(
-                  color: Color(0xffBBBBBB),
-                ),
-              ),
-            ),
+                    onNotification: (notification) {
+                      if (notification is ScrollStartNotification) {
+                        // スクロールが開始された場合の処理(非表示)
+                        ref
+                            .read(isResultCountVisibleProvider.notifier)
+                            .update((state) => false);
+                      } else if (notification is ScrollEndNotification) {
+                        // スクロールが終了した場合の処理(表示)
+                        ref
+                            .read(isResultCountVisibleProvider.notifier)
+                            .update((state) => true);
+                      }
+                      return true;
+                    },
+                    child: ListView.separated(
+                      //スクロールでキーボードを閉じるようにした
+                      keyboardDismissBehavior:
+                          ScrollViewKeyboardDismissBehavior.onDrag,
+                      itemCount: totalCount,
+                      itemBuilder: (context, index) {
+                        return ProviderScope(
+                          overrides: [
+                            listIndexProvider.overrideWithValue(index)
+                          ],
+                          child: const ListItem(),
+                        );
+                      },
+                      separatorBuilder: (context, index) => const Divider(
+                        color: Color(0xffBBBBBB),
+                      ),
+                    ),
+                  ),
             error: (e, _) {
               if (e is NoTextException) {
                 return const EnterTextView();
@@ -102,9 +100,7 @@ class ResultListview extends ConsumerWidget {
           borderRadius: BorderRadius.circular(5),
         ),
         child: Text(
-          '${NumberFormat('#,##0').format(resultCount.value)}${S
-              .of(context)
-              .result}',
+          '${NumberFormat('#,##0').format(resultCount.value)}${S.of(context).result}',
           style: TextStyle(
             color: resultCountColor.count,
             fontSize: 16,

--- a/lib/presentation/search/widget/result_list_view.dart
+++ b/lib/presentation/search/widget/result_list_view.dart
@@ -14,6 +14,9 @@ import 'list_item_shimmer.dart';
 class ResultListview extends ConsumerWidget {
   const ResultListview({Key? key}) : super(key: key);
 
+  @visibleForTesting
+  static final resultCountKey = UniqueKey();
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     //検索数
@@ -24,44 +27,46 @@ class ResultListview extends ConsumerWidget {
         alignment: Alignment.bottomCenter,
         children: [
           resultCount.when(
-            data: (totalCount) => totalCount == 0
-                //検索結果がない場合
+            data: (totalCount) =>
+            totalCount == 0
+            //検索結果がない場合
                 ? const NoResultView()
-                //検索結果がある場合
-                //スクロールを検知して、スクロール中は検索結果数を表示しないようにする
+            //検索結果がある場合
+            //スクロールを検知して、スクロール中は検索結果数を表示しないようにする
                 : NotificationListener<ScrollNotification>(
-                    onNotification: (notification) {
-                      if (notification is ScrollStartNotification) {
-                        // スクロールが開始された場合の処理(非表示)
-                        ref
-                            .read(isResultCountVisibleProvider.notifier)
-                            .update((state) => false);
-                      } else if (notification is ScrollEndNotification) {
-                        // スクロールが終了した場合の処理(表示)
-                        ref
-                            .read(isResultCountVisibleProvider.notifier)
-                            .update((state) => true);
-                      }
-                      return true;
-                    },
-                    child: ListView.separated(
-                      //スクロールでキーボードを閉じるようにした
-                      keyboardDismissBehavior:
-                          ScrollViewKeyboardDismissBehavior.onDrag,
-                      itemCount: totalCount,
-                      itemBuilder: (context, index) {
-                        return ProviderScope(
-                          overrides: [
-                            listIndexProvider.overrideWithValue(index)
-                          ],
-                          child: const ListItem(),
-                        );
-                      },
-                      separatorBuilder: (context, index) => const Divider(
-                        color: Color(0xffBBBBBB),
-                      ),
-                    ),
-                  ),
+              onNotification: (notification) {
+                if (notification is ScrollStartNotification) {
+                  // スクロールが開始された場合の処理(非表示)
+                  ref
+                      .read(isResultCountVisibleProvider.notifier)
+                      .update((state) => false);
+                } else if (notification is ScrollEndNotification) {
+                  // スクロールが終了した場合の処理(表示)
+                  ref
+                      .read(isResultCountVisibleProvider.notifier)
+                      .update((state) => true);
+                }
+                return true;
+              },
+              child: ListView.separated(
+                //スクロールでキーボードを閉じるようにした
+                keyboardDismissBehavior:
+                ScrollViewKeyboardDismissBehavior.onDrag,
+                itemCount: totalCount,
+                itemBuilder: (context, index) {
+                  return ProviderScope(
+                    overrides: [
+                      listIndexProvider.overrideWithValue(index)
+                    ],
+                    child: const ListItem(),
+                  );
+                },
+                separatorBuilder: (context, index) =>
+                const Divider(
+                  color: Color(0xffBBBBBB),
+                ),
+              ),
+            ),
             error: (e, _) {
               if (e is NoTextException) {
                 return const EnterTextView();
@@ -97,13 +102,15 @@ class ResultListview extends ConsumerWidget {
           borderRadius: BorderRadius.circular(5),
         ),
         child: Text(
-          '${NumberFormat('#,##0').format(resultCount.value)}${S.of(context).result}',
+          '${NumberFormat('#,##0').format(resultCount.value)}${S
+              .of(context)
+              .result}',
           style: TextStyle(
             color: resultCountColor.count,
             fontSize: 16,
             fontWeight: FontWeight.bold,
           ),
-          key: const Key('resultCount'),
+          key: resultCountKey,
         ),
       ),
     );

--- a/lib/presentation/search/widget/search_app_bar.dart
+++ b/lib/presentation/search/widget/search_app_bar.dart
@@ -10,7 +10,7 @@ class SearchAppBar extends ConsumerWidget implements PreferredSizeWidget {
   const SearchAppBar({super.key});
 
   @visibleForTesting
-  static final searchPageAppBarKey = UniqueKey();
+  static final appBarKey = UniqueKey();
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
@@ -27,7 +27,7 @@ class SearchAppBar extends ConsumerWidget implements PreferredSizeWidget {
     //theme切り替えのプロバイダ
     final themeSelector = ref.read(themeModeProvider.notifier);
     return AppBar(
-      key: searchPageAppBarKey,
+      key: appBarKey,
       title: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[

--- a/lib/presentation/search/widget/search_app_bar.dart
+++ b/lib/presentation/search/widget/search_app_bar.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/toggle_theme_switch.dart';
 import '../../../generated/l10n.dart';
 import '../../../theme/theme_mode_provider.dart';

--- a/lib/presentation/search/widget/search_app_bar.dart
+++ b/lib/presentation/search/widget/search_app_bar.dart
@@ -9,6 +9,9 @@ import '../../../theme/theme_mode_provider.dart';
 class SearchAppBar extends ConsumerWidget implements PreferredSizeWidget {
   const SearchAppBar({super.key});
 
+  @visibleForTesting
+  static final searchPageAppBarKey = UniqueKey();
+
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 
@@ -16,20 +19,24 @@ class SearchAppBar extends ConsumerWidget implements PreferredSizeWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     //スイッチの初期値判定のためのシステムテーマモード取得
     final systemThemeMode =
-        MediaQuery.of(context).platformBrightness == Brightness.dark
-            ? ThemeMode.dark
-            : ThemeMode.light;
+    MediaQuery
+        .of(context)
+        .platformBrightness == Brightness.dark
+        ? ThemeMode.dark
+        : ThemeMode.light;
     //現在のテーマモード取得
     final themeMode = ref.watch(themeModeProvider);
     //theme切り替えのプロバイダ
     final themeSelector = ref.read(themeModeProvider.notifier);
     return AppBar(
-      key: const Key('searchPageAppBar'),
+      key: searchPageAppBarKey,
       title: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
           Text(
-            S.of(context).searchPageTitle,
+            S
+                .of(context)
+                .searchPageTitle,
           ),
           ToggleThemeSwitch(
             //themeModeが初期（SYSTEM）状態だったらその情報を使って表示を処理する

--- a/lib/presentation/search/widget/search_app_bar.dart
+++ b/lib/presentation/search/widget/search_app_bar.dart
@@ -19,11 +19,9 @@ class SearchAppBar extends ConsumerWidget implements PreferredSizeWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     //スイッチの初期値判定のためのシステムテーマモード取得
     final systemThemeMode =
-    MediaQuery
-        .of(context)
-        .platformBrightness == Brightness.dark
-        ? ThemeMode.dark
-        : ThemeMode.light;
+        MediaQuery.of(context).platformBrightness == Brightness.dark
+            ? ThemeMode.dark
+            : ThemeMode.light;
     //現在のテーマモード取得
     final themeMode = ref.watch(themeModeProvider);
     //theme切り替えのプロバイダ
@@ -34,9 +32,7 @@ class SearchAppBar extends ConsumerWidget implements PreferredSizeWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
           Text(
-            S
-                .of(context)
-                .searchPageTitle,
+            S.of(context).searchPageTitle,
           ),
           ToggleThemeSwitch(
             //themeModeが初期（SYSTEM）状態だったらその情報を使って表示を処理する

--- a/lib/presentation/search/widget/search_app_bar.dart
+++ b/lib/presentation/search/widget/search_app_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/toggle_theme_switch.dart';
 import '../../../generated/l10n.dart';

--- a/lib/presentation/search/widget/search_app_bar.dart
+++ b/lib/presentation/search/widget/search_app_bar.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/toggle_theme_switch.dart';
 import '../../../generated/l10n.dart';
 import '../../../theme/theme_mode_provider.dart';

--- a/lib/presentation/search/widget/search_bar.dart
+++ b/lib/presentation/search/widget/search_bar.dart
@@ -18,7 +18,6 @@ class SearchBar extends ConsumerWidget {
   @visibleForTesting
   static final sortButtonKey = UniqueKey();
 
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     //テキストのコントローラ
@@ -51,21 +50,19 @@ class SearchBar extends ConsumerWidget {
                 },
                 //decoration
                 decoration: InputDecoration(
-                  hintText: S
-                      .of(context)
-                      .formHintText,
+                  hintText: S.of(context).formHintText,
                   prefixIcon: const Icon(Icons.search, size: 27),
                   suffixIcon: ref.watch(isClearButtonVisibleProvider)
                       ? IconButton(
-                    icon: const Icon(Icons.clear, size: 27),
-                    onPressed: () {
-                      textController.clear();
-                      ref
-                          .watch(isClearButtonVisibleProvider.notifier)
-                          .update((state) => false);
-                    },
-                    key: clearButtonKey,
-                  )
+                          icon: const Icon(Icons.clear, size: 27),
+                          onPressed: () {
+                            textController.clear();
+                            ref
+                                .watch(isClearButtonVisibleProvider.notifier)
+                                .update((state) => false);
+                          },
+                          key: clearButtonKey,
+                        )
                       : const SizedBox.shrink(),
                 ),
                 key: inputFormKey,
@@ -79,57 +76,42 @@ class SearchBar extends ConsumerWidget {
                 RadioMenuButton(
                   value: 'bestmatch',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) =>
-                      ref
-                          .read(sortStringProvider.notifier)
-                          .update((state) => value!),
-                  child: Text(S
-                      .of(context)
-                      .bestMatch),
+                  onChanged: (value) => ref
+                      .read(sortStringProvider.notifier)
+                      .update((state) => value!),
+                  child: Text(S.of(context).bestMatch),
                 ),
                 RadioMenuButton(
                   value: 'updated',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) =>
-                      ref
-                          .read(sortStringProvider.notifier)
-                          .update((state) => value!),
-                  child: Text(S
-                      .of(context)
-                      .updated),
+                  onChanged: (value) => ref
+                      .read(sortStringProvider.notifier)
+                      .update((state) => value!),
+                  child: Text(S.of(context).updated),
                 ),
                 RadioMenuButton(
                   value: 'stars',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) =>
-                      ref
-                          .read(sortStringProvider.notifier)
-                          .update((state) => value!),
-                  child: Text(S
-                      .of(context)
-                      .stars),
+                  onChanged: (value) => ref
+                      .read(sortStringProvider.notifier)
+                      .update((state) => value!),
+                  child: Text(S.of(context).stars),
                 ),
                 RadioMenuButton(
                   value: 'forks',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) =>
-                      ref
-                          .read(sortStringProvider.notifier)
-                          .update((state) => value!),
-                  child: Text(S
-                      .of(context)
-                      .forks),
+                  onChanged: (value) => ref
+                      .read(sortStringProvider.notifier)
+                      .update((state) => value!),
+                  child: Text(S.of(context).forks),
                 ),
                 RadioMenuButton(
                   value: 'help-wanted-issues',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) =>
-                      ref
-                          .read(sortStringProvider.notifier)
-                          .update((state) => value!),
-                  child: Text(S
-                      .of(context)
-                      .helpWantedIssue),
+                  onChanged: (value) => ref
+                      .read(sortStringProvider.notifier)
+                      .update((state) => value!),
+                  child: Text(S.of(context).helpWantedIssue),
                 ),
               ],
               builder: (BuildContext context, MenuController controller,

--- a/lib/presentation/search/widget/search_bar.dart
+++ b/lib/presentation/search/widget/search_bar.dart
@@ -8,6 +8,17 @@ import '../../controller/controllers.dart';
 class SearchBar extends ConsumerWidget {
   const SearchBar({Key? key}) : super(key: key);
 
+  //テスト用のKEY
+  @visibleForTesting
+  static final inputFormKey = UniqueKey();
+  @visibleForTesting
+  static final clearButtonKey = UniqueKey();
+  @visibleForTesting
+  static final sortRadioKey = UniqueKey();
+  @visibleForTesting
+  static final sortButtonKey = UniqueKey();
+
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     //テキストのコントローラ
@@ -40,68 +51,85 @@ class SearchBar extends ConsumerWidget {
                 },
                 //decoration
                 decoration: InputDecoration(
-                  hintText: S.of(context).formHintText,
+                  hintText: S
+                      .of(context)
+                      .formHintText,
                   prefixIcon: const Icon(Icons.search, size: 27),
                   suffixIcon: ref.watch(isClearButtonVisibleProvider)
                       ? IconButton(
-                          icon: const Icon(Icons.clear, size: 27),
-                          onPressed: () {
-                            textController.clear();
-                            ref
-                                .watch(isClearButtonVisibleProvider.notifier)
-                                .update((state) => false);
-                          },
-                          key: const Key('clearButton'),
-                        )
+                    icon: const Icon(Icons.clear, size: 27),
+                    onPressed: () {
+                      textController.clear();
+                      ref
+                          .watch(isClearButtonVisibleProvider.notifier)
+                          .update((state) => false);
+                    },
+                    key: clearButtonKey,
+                  )
                       : const SizedBox.shrink(),
                 ),
-                key: const Key('inputForm'),
+                key: inputFormKey,
               ),
             ),
             //ソートボタン
             MenuAnchor(
-              key: const Key('sortRadio'),
+              key: sortRadioKey,
               alignmentOffset: const Offset(-120, 0),
               menuChildren: [
                 RadioMenuButton(
                   value: 'bestmatch',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) => ref
-                      .read(sortStringProvider.notifier)
-                      .update((state) => value!),
-                  child: Text(S.of(context).bestMatch),
+                  onChanged: (value) =>
+                      ref
+                          .read(sortStringProvider.notifier)
+                          .update((state) => value!),
+                  child: Text(S
+                      .of(context)
+                      .bestMatch),
                 ),
                 RadioMenuButton(
                   value: 'updated',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) => ref
-                      .read(sortStringProvider.notifier)
-                      .update((state) => value!),
-                  child: Text(S.of(context).updated),
+                  onChanged: (value) =>
+                      ref
+                          .read(sortStringProvider.notifier)
+                          .update((state) => value!),
+                  child: Text(S
+                      .of(context)
+                      .updated),
                 ),
                 RadioMenuButton(
                   value: 'stars',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) => ref
-                      .read(sortStringProvider.notifier)
-                      .update((state) => value!),
-                  child: Text(S.of(context).stars),
+                  onChanged: (value) =>
+                      ref
+                          .read(sortStringProvider.notifier)
+                          .update((state) => value!),
+                  child: Text(S
+                      .of(context)
+                      .stars),
                 ),
                 RadioMenuButton(
                   value: 'forks',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) => ref
-                      .read(sortStringProvider.notifier)
-                      .update((state) => value!),
-                  child: Text(S.of(context).forks),
+                  onChanged: (value) =>
+                      ref
+                          .read(sortStringProvider.notifier)
+                          .update((state) => value!),
+                  child: Text(S
+                      .of(context)
+                      .forks),
                 ),
                 RadioMenuButton(
                   value: 'help-wanted-issues',
                   groupValue: ref.watch(sortStringProvider),
-                  onChanged: (value) => ref
-                      .read(sortStringProvider.notifier)
-                      .update((state) => value!),
-                  child: Text(S.of(context).helpWantedIssue),
+                  onChanged: (value) =>
+                      ref
+                          .read(sortStringProvider.notifier)
+                          .update((state) => value!),
+                  child: Text(S
+                      .of(context)
+                      .helpWantedIssue),
                 ),
               ],
               builder: (BuildContext context, MenuController controller,
@@ -115,7 +143,7 @@ class SearchBar extends ConsumerWidget {
                     }
                   },
                   icon: const Icon(Icons.sort, size: 32),
-                  key: const Key('sortButton'),
+                  key: sortButtonKey,
                 );
               },
             ),

--- a/test/helper/helper_test.dart
+++ b/test/helper/helper_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+class Helper {
+  //初期状態は横画面判定になっているので縦画面に設定する
+  static void setDisplayVertical({Size size = const Size(390, 844)}) {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.window.physicalSizeTestValue = size;
+    binding.window.devicePixelRatioTestValue = 1;
+  }
+}

--- a/test/helper/test_helper.dart
+++ b/test/helper/test_helper.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
-class Helper {
+class TestHelper {
   //初期状態は横画面判定になっているので縦画面に設定する
   static void setDisplayVertical({Size size = const Size(390, 844)}) {
     final binding = TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/presentation/error_test.dart
+++ b/test/presentation/error_test.dart
@@ -8,6 +8,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:yumemi_flutter_repo_search/domain/error.dart';
 import 'package:yumemi_flutter_repo_search/main.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/error/error_widget.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
 import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 import '../repository/repository_mock_data.dart';
@@ -34,7 +36,7 @@ void main() {
       );
 
       //""と入力して検索する
-      final formField = find.byKey(const Key('inputForm'));
+      final formField = find.byKey(SearchBar.inputFormKey);
       await tester.enterText(formField, '');
       await tester.tap(formField);
       await tester.testTextInput.receiveAction(TextInputAction.search);
@@ -42,7 +44,7 @@ void main() {
       await tester.pump();
 
       //エラーが返ってくる("テキストを入力してください")
-      expect(find.byKey(const Key('enterTextView')), findsOneWidget);
+      expect(find.byKey(EnterTextView.enterTextViewKey), findsOneWidget);
     });
 
     testWidgets('結果が0だった時に、想定の表示がされるか', (WidgetTester tester) async {
@@ -63,7 +65,7 @@ void main() {
       );
 
       //入力して検索する
-      final formField = find.byKey(const Key('inputForm'));
+      final formField = find.byKey(SearchBar.inputFormKey);
       await tester.enterText(formField, 'kjsdf；ヵjdf；kぁjsdfj');
       await tester.tap(formField);
       await tester.testTextInput.receiveAction(TextInputAction.search);
@@ -73,7 +75,7 @@ void main() {
       await tester.pump();
 
       //エラーが返ってくる("検索結果が見つからない")
-      expect(find.byKey(const Key('noResultView')), findsOneWidget);
+      expect(find.byKey(NoResultView.noResultViewKey), findsOneWidget);
     });
 
     testWidgets('リクエストが200以外の場合エラーが返るか', (WidgetTester tester) async {
@@ -94,7 +96,7 @@ void main() {
       );
 
       //"flutter"と入力して検索する
-      final formField = find.byKey(const Key('inputForm'));
+      final formField = find.byKey(SearchBar.inputFormKey);
       await tester.enterText(formField, 'flutter');
       await tester.tap(formField);
       await tester.testTextInput.receiveAction(TextInputAction.search);
@@ -104,7 +106,7 @@ void main() {
       await tester.pump();
 
       //エラーが返ってくる
-      expect(find.byKey(const Key('errorView')), findsOneWidget);
+      expect(find.byKey(ErrorView.errorViewKey), findsOneWidget);
     });
 
     testWidgets('通信状態じゃない時の検索でネットワークエラーが返るか', (WidgetTester tester) async {
@@ -127,7 +129,7 @@ void main() {
       );
 
       //"flutter"と入力して検索する
-      final formField = find.byKey(const Key('inputForm'));
+      final formField = find.byKey(SearchBar.inputFormKey);
       await tester.enterText(formField, 'flutter');
       //検索ボタンを押す
       await tester.tap(formField);
@@ -141,7 +143,7 @@ void main() {
       expect(find.textContaining('flutter/flutter'), findsNothing);
 
       //想定エラー文
-      expect(find.byKey(const Key('networkErrorView')), findsOneWidget);
+      expect(find.byKey(NetworkErrorView.networkErrorViewKey), findsOneWidget);
     });
   });
 }

--- a/test/presentation/error_test.dart
+++ b/test/presentation/error_test.dart
@@ -69,7 +69,7 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.search);
 
       //結果表示されるまで待つ
-      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
       await tester.pump();
 
       //エラーが返ってくる("検索結果が見つからない")
@@ -100,7 +100,7 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.search);
 
       //エラー表示されるまで待つ
-      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
       await tester.pump();
 
       //エラーが返ってくる
@@ -134,7 +134,7 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.search);
 
       //エラーが表示されるまで待つ
-      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
       await tester.pump();
 
       //トップの結果は表示されない

--- a/test/presentation/error_test.dart
+++ b/test/presentation/error_test.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;

--- a/test/presentation/input_search_test.dart
+++ b/test/presentation/input_search_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -7,12 +8,27 @@ import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:yumemi_flutter_repo_search/main.dart';
+import 'package:yumemi_flutter_repo_search/presentation/detail/detail_page.dart';
+import 'package:yumemi_flutter_repo_search/presentation/detail/widget/detail_element.dart';
+import 'package:yumemi_flutter_repo_search/presentation/detail/widget/ver_repo_header.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/list_item.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/result_list_view.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
 import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 import '../repository/repository_mock_data.dart';
 import '../repository/repository_mock_test.mocks.dart';
 
 void main() {
+  //初期状態は横画面判定になっているので縦画面に設定する
+  void setDisplayVertical({Size size = const Size(390, 844)}) {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.window.physicalSizeTestValue = size;
+    binding.window.devicePixelRatioTestValue = 1;
+  }
+
+  setDisplayVertical();
+
   group('入力フォームのテスト', () {
     testWidgets('検索フォームのテスト', (WidgetTester tester) async {
       //モックのデータをshared_preferencesにセットしておかないといけない
@@ -32,7 +48,7 @@ void main() {
         ], child: const MyApp()),
       );
       //検索フォーム
-      final formField = find.byKey(const Key('inputForm'));
+      final formField = find.byKey(SearchBar.inputFormKey);
       //検索フォームがあるか
       expect(formField, findsOneWidget);
       //初期状態でヒントテキストが表示されているか(英語でテストできてるみたい)
@@ -79,7 +95,7 @@ void main() {
       );
 
       //検索フォーム
-      final formField = find.byKey(const Key('inputForm'));
+      final formField = find.byKey(SearchBar.inputFormKey);
       //flutterと入力して検索する
       await tester.enterText(formField, 'flutter');
       await tester.tap(formField);
@@ -94,9 +110,9 @@ void main() {
       final tapTarget = find.text('flutter/flutter');
       expect(tapTarget, findsOneWidget);
       //ユーザーアイコンが表示されるか
-      expect(find.byKey(const Key('userImageOnListView')), findsWidgets);
+      expect(find.byKey(ListItem.userImageOnListViewKey), findsWidgets);
       //検索結果数が表示されるか
-      expect(find.byKey(const Key('resultCount')), findsOneWidget);
+      expect(find.byKey(ResultListview.resultCountKey), findsOneWidget);
     });
   });
 
@@ -119,7 +135,7 @@ void main() {
       );
 
       //検索フォーム
-      final formField = find.byKey(const Key('inputForm'));
+      final formField = find.byKey(SearchBar.inputFormKey);
       //flutterと入力して検索する
       await tester.enterText(formField, 'flutter');
       await tester.tap(formField);
@@ -139,21 +155,34 @@ void main() {
       await tester.pump();
 
       //詳細ページのアップバーが表示されるか
-      expect(find.byKey(const Key('detailPageAppBar')), findsOneWidget);
+      expect(find.byKey(DetailPage.detailPageAppBarKey), findsOneWidget);
       //ユーザーのアイコンが表示されるか
-      expect(find.byKey(const Key('userImageOnDetailPage')), findsOneWidget);
+      expect(
+          find.byKey(VerRepoHeader.userImageOnDetailPageKey), findsOneWidget);
+      //横画面用テスト
+      // expect(
+      //     find.byKey(HoriRepoHeader.userImageOnDetailPageKey), findsOneWidget);
+
       //詳細ページのレポジトリ名が表示される
-      expect(find.byKey(const Key('repoNameOnDetailPage')), findsOneWidget);
+      expect(find.byKey(VerRepoHeader.repoNameOnDetailPageKey), findsOneWidget);
+      //横画面用テスト
+      // expect(
+      //     find.byKey(HoriRepoHeader.repoNameOnDetailPageKey), findsOneWidget);
+
       //詳細ページのレポジトリ詳細が表示される
-      expect(find.byKey(const Key('repoDetailOnDetailPage')), findsOneWidget);
+      expect(
+          find.byKey(VerRepoHeader.repoDetailOnDetailPageKey), findsOneWidget);
+      //横画面用テスト
+      // expect(
+      //     find.byKey(HoriRepoHeader.repoDetailOnDetailPageKey), findsOneWidget);
 
       //その他の情報が表示されるか
-      expect(find.byKey(const Key('language')), findsOneWidget);
-      expect(find.byKey(const Key('star')), findsOneWidget);
-      expect(find.byKey(const Key('watch')), findsOneWidget);
-      expect(find.byKey(const Key('fork')), findsOneWidget);
-      expect(find.byKey(const Key('issue')), findsOneWidget);
-      expect(find.byKey(const Key('viewOnGithub')), findsOneWidget);
+      expect(find.byKey(DetailElement.languageKey), findsOneWidget);
+      expect(find.byKey(DetailElement.starKey), findsOneWidget);
+      expect(find.byKey(DetailElement.watchKey), findsOneWidget);
+      expect(find.byKey(DetailElement.forkKey), findsOneWidget);
+      expect(find.byKey(DetailElement.issueKey), findsOneWidget);
+      expect(find.byKey(DetailPage.viewOnGithubKey), findsOneWidget);
     });
   });
 }

--- a/test/presentation/input_search_test.dart
+++ b/test/presentation/input_search_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/presentation/input_search_test.dart
+++ b/test/presentation/input_search_test.dart
@@ -15,12 +15,12 @@ import 'package:yumemi_flutter_repo_search/presentation/search/widget/result_lis
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
 import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
-import '../helper/helper_test.dart';
+import '../helper/test_helper.dart';
 import '../repository/repository_mock_data.dart';
 import '../repository/repository_mock_test.mocks.dart';
 
 void main() {
-  Helper.setDisplayVertical();
+  TestHelper.setDisplayVertical();
 
   group('入力フォームのテスト', () {
     testWidgets('検索フォームのテスト', (WidgetTester tester) async {

--- a/test/presentation/input_search_test.dart
+++ b/test/presentation/input_search_test.dart
@@ -136,13 +136,14 @@ void main() {
       //検索フォーム
       final formField = find.byKey(SearchBar.inputFormKey);
       //flutterと入力して検索する
-      await tester.enterText(formField, 'flutter');
       await tester.tap(formField);
+      await tester.enterText(formField, 'flutter');
       //検索ボタンを押す
       await tester.testTextInput.receiveAction(TextInputAction.search);
 
+      //shimmerが描画される
+      await tester.pump();
       //リストが描画される
-      await tester.pump(const Duration(seconds: 3));
       await tester.pump();
 
       //リストをタップ→詳細ページに遷移
@@ -150,7 +151,7 @@ void main() {
       await tester.tap(tapTarget);
 
       //画面遷移するまで待つ
-      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
       await tester.pump();
 
       //詳細ページのアップバーが表示されるか

--- a/test/presentation/input_search_test.dart
+++ b/test/presentation/input_search_test.dart
@@ -102,14 +102,14 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.search);
 
       //リストが描画される
-      await tester.pump(const Duration(seconds: 3));
+      await tester.pump(const Duration(seconds: 2));
       await tester.pump();
 
       //"flutter/flutter" と言う文字が見つかるか
       final tapTarget = find.text('flutter/flutter');
       expect(tapTarget, findsOneWidget);
       //ユーザーアイコンが表示されるか
-      expect(find.byKey(ListItem.userImageOnListViewKey), findsWidgets);
+      expect(find.byKey(ListItem.userImageKey), findsWidgets);
       //検索結果数が表示されるか
       expect(find.byKey(ResultListview.resultCountKey), findsOneWidget);
     });
@@ -154,23 +154,21 @@ void main() {
       await tester.pump();
 
       //詳細ページのアップバーが表示されるか
-      expect(find.byKey(DetailPage.detailPageAppBarKey), findsOneWidget);
+      expect(find.byKey(DetailPage.appBarKey), findsOneWidget);
       //ユーザーのアイコンが表示されるか
-      expect(
-          find.byKey(VerRepoHeader.userImageOnDetailPageKey), findsOneWidget);
+      expect(find.byKey(VerRepoHeader.userImageKey), findsOneWidget);
       //横画面用テスト
       // expect(
       //     find.byKey(HoriRepoHeader.userImageOnDetailPageKey), findsOneWidget);
 
       //詳細ページのレポジトリ名が表示される
-      expect(find.byKey(VerRepoHeader.repoNameOnDetailPageKey), findsOneWidget);
+      expect(find.byKey(VerRepoHeader.repoNameKey), findsOneWidget);
       //横画面用テスト
       // expect(
       //     find.byKey(HoriRepoHeader.repoNameOnDetailPageKey), findsOneWidget);
 
       //詳細ページのレポジトリ詳細が表示される
-      expect(
-          find.byKey(VerRepoHeader.repoDetailOnDetailPageKey), findsOneWidget);
+      expect(find.byKey(VerRepoHeader.repoDetailKey), findsOneWidget);
       //横画面用テスト
       // expect(
       //     find.byKey(HoriRepoHeader.repoDetailOnDetailPageKey), findsOneWidget);

--- a/test/presentation/input_search_test.dart
+++ b/test/presentation/input_search_test.dart
@@ -96,7 +96,7 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.search);
 
       //リストが描画される
-      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
       await tester.pump();
 
       //"flutter/flutter" と言う文字が見つかるか

--- a/test/presentation/input_search_test.dart
+++ b/test/presentation/input_search_test.dart
@@ -15,18 +15,12 @@ import 'package:yumemi_flutter_repo_search/presentation/search/widget/result_lis
 import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 import 'package:yumemi_flutter_repo_search/repository/http_client.dart';
 import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
+import '../helper/helper_test.dart';
 import '../repository/repository_mock_data.dart';
 import '../repository/repository_mock_test.mocks.dart';
 
 void main() {
-  //初期状態は横画面判定になっているので縦画面に設定する
-  void setDisplayVertical({Size size = const Size(390, 844)}) {
-    final binding = TestWidgetsFlutterBinding.ensureInitialized();
-    binding.window.physicalSizeTestValue = size;
-    binding.window.devicePixelRatioTestValue = 1;
-  }
-
-  setDisplayVertical();
+  Helper.setDisplayVertical();
 
   group('入力フォームのテスト', () {
     testWidgets('検索フォームのテスト', (WidgetTester tester) async {
@@ -158,21 +152,12 @@ void main() {
       expect(find.byKey(DetailPage.appBarKey), findsOneWidget);
       //ユーザーのアイコンが表示されるか
       expect(find.byKey(VerRepoHeader.userImageKey), findsOneWidget);
-      //横画面用テスト
-      // expect(
-      //     find.byKey(HoriRepoHeader.userImageOnDetailPageKey), findsOneWidget);
 
       //詳細ページのレポジトリ名が表示される
       expect(find.byKey(VerRepoHeader.repoNameKey), findsOneWidget);
-      //横画面用テスト
-      // expect(
-      //     find.byKey(HoriRepoHeader.repoNameOnDetailPageKey), findsOneWidget);
 
       //詳細ページのレポジトリ詳細が表示される
       expect(find.byKey(VerRepoHeader.repoDetailKey), findsOneWidget);
-      //横画面用テスト
-      // expect(
-      //     find.byKey(HoriRepoHeader.repoDetailOnDetailPageKey), findsOneWidget);
 
       //その他の情報が表示されるか
       expect(find.byKey(DetailElement.languageKey), findsOneWidget);

--- a/test/presentation/sort_list_test.dart
+++ b/test/presentation/sort_list_test.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:yumemi_flutter_repo_search/main.dart';
 import 'package:yumemi_flutter_repo_search/presentation/controller/controllers.dart';
+import 'package:yumemi_flutter_repo_search/presentation/search/widget/search_bar.dart';
 import 'package:yumemi_flutter_repo_search/theme/shared_preferences_provider.dart';
 
 void main() {
@@ -21,7 +22,7 @@ void main() {
     );
 
     //sortボタンがあるか
-    final sortButton = find.byKey(const Key('sortButton'));
+    final sortButton = find.byKey(SearchBar.sortButtonKey);
     expect(sortButton, findsOneWidget);
 
     //ソートボタンをタップする

--- a/test/repository/repository_mock_test.dart
+++ b/test/repository/repository_mock_test.dart
@@ -23,23 +23,18 @@ void main() {
 
     late ProviderContainer container;
 
-    setUp(() => () {
-          //mockのhttpクライアントでDIする
-          container = ProviderContainer(
-            overrides: [httpClientProvider.overrideWithValue(mockClient)],
-          );
-        });
-
-    tearDown(() => () {
-          container.dispose();
-        });
-
-    test('getメソッドのテスト', () async {
+    setUp(() {
       //mockのhttpクライアントでDIする
       container = ProviderContainer(
         overrides: [httpClientProvider.overrideWithValue(mockClient)],
       );
+    });
 
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('getメソッドのテスト', () async {
       //上でオーバーライドされたmockのHTTPクライアントのインスタンスをみれてる
       final result = await container
           .read(dataRepositoryProvider)


### PR DESCRIPTION
## 概要
#57 対応
やったことを簡単に書く
* テストで使うkeyに@visibleForTestingアノテーションをつける
* その他、テストの改善
* テスト以外から参照したらエラーになるようにlint対応する

## 相談したいこと、とくに確認して欲しいところ
ここの実装方法はこれでいいか？とか

## テスト
* ウィジェットテストはデフォルトで横画面なので、テストコードに画面を縦に固定するコードを追加した
* 文字列のkeyを使ってテストしていたが、UniqueKeyに変更した

## その他
[Fix/issue69 fix error handling](https://github.com/mqkotoo/yumemi_flutter_repo_search/pull/70#top) での対応漏れがあったので、こちらで修正した